### PR TITLE
Add calendar links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+.github/copilot-instructions.md

--- a/events_listing/_layouts/event.html
+++ b/events_listing/_layouts/event.html
@@ -76,6 +76,21 @@ title: "{{ page.Name | escape_once }}"
   </div>
   {% endif %}
 
+  <div class="bg-purple-50 p-6 rounded-xl shadow-md mb-6">
+    <h2 class="event-details-section-title">
+      <span class="text-3xl mr-3">📅</span>
+      Adicionar ao Calendário
+    </h2>
+    <div class="flex flex-col sm:flex-row gap-3">
+      <a href="{{ page | google_calendar_url }}" target="_blank" rel="noopener noreferrer" class="flex items-center justify-center flex-1 navigation-button">
+        Google Calendar
+      </a>
+      <a href="data:text/calendar;charset=utf-8,{{ page | event_to_ics | url_encode }}" download="{{ page.Name | slugify }}.ics" class="flex items-center justify-center flex-1 navigation-button">
+        Apple Calendar
+      </a>
+    </div>
+  </div>
+
   <!-- Sharing Section -->
   <div class="bg-gradient-to-r from-red-50 to-rose-50 p-6 rounded-xl shadow-md mb-6">
     <h2 class="event-details-section-title">

--- a/events_listing/_layouts/event.html
+++ b/events_listing/_layouts/event.html
@@ -78,7 +78,7 @@ title: "{{ page.Name | escape_once }}"
 
   <div class="bg-purple-50 p-6 rounded-xl shadow-md mb-6">
     <h2 class="event-details-section-title">
-      <span class="text-3xl mr-3">📅</span>
+      <span class="text-3xl mr-3">🗓️</span>
       Adicionar ao Calendário
     </h2>
     <div class="flex flex-col sm:flex-row gap-3">

--- a/events_listing/_plugins/calendar_helpers.rb
+++ b/events_listing/_plugins/calendar_helpers.rb
@@ -1,0 +1,58 @@
+module Jekyll
+  module CalendarHelpers
+    require 'time'
+    require 'uri'
+    require 'icalendar'
+
+    # Generate a Google Calendar URL for an event hash
+    def google_calendar_url(event, timezone = 'Europe/Lisbon')
+      start_time = parse_time(event['Start date'], event['Start time'])
+      end_time = parse_time(event['End date'], event['End time'])
+      return '' unless start_time && end_time
+
+      params = {
+        action: 'TEMPLATE',
+        text: event['Name'].to_s.strip,
+        dates: "#{format_google_time(start_time)}/#{format_google_time(end_time)}",
+        details: event['Description'].to_s.strip,
+        location: event['Location'].to_s.strip,
+        ctz: timezone
+      }
+      "https://www.google.com/calendar/render?" + URI.encode_www_form(params)
+    end
+
+    # Generate an ICS string for an event hash
+    def event_to_ics(event)
+      start_time = parse_time(event['Start date'], event['Start time'])
+      end_time = parse_time(event['End date'], event['End time'])
+      cal = Icalendar::Calendar.new
+      cal.append_custom_property('X-WR-CALNAME', 'PXOPulse Event')
+      ev = Icalendar::Event.new
+      ev.dtstart = start_time if start_time
+      ev.dtend = end_time if end_time
+      ev.summary = event['Name'].to_s.strip
+      ev.location = event['Location'].to_s.strip
+      ev.description = event['Description'].to_s.strip
+      cal.add_event(ev)
+      cal.publish
+      cal.to_ical
+    end
+
+    private
+
+    def parse_time(date_str, time_str)
+      return nil if date_str.nil? || date_str.to_s.strip.empty?
+      str = date_str.to_s
+      str += " #{time_str}" if time_str && !time_str.to_s.strip.empty?
+      Time.parse(str)
+    rescue StandardError
+      nil
+    end
+
+    def format_google_time(t)
+      t.utc.strftime('%Y%m%dT%H%M%SZ')
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::CalendarHelpers)

--- a/events_listing/_plugins/calendar_helpers.rb
+++ b/events_listing/_plugins/calendar_helpers.rb
@@ -7,17 +7,17 @@ module Jekyll
     require "icalendar"
 
     # Generate a Google Calendar URL for an event hash
-    def google_calendar_url(event, timezone = 'Europe/Lisbon')
-      start_time = parse_time(event['Start date'], event['Start time'])
-      end_time = parse_time(event['End date'], event['End time'])
-      return '' unless start_time && end_time
+    def google_calendar_url(event, timezone = "Europe/Lisbon")
+      start_time = parse_time(event["Start date"], event["Start time"])
+      end_time = parse_time(event["End date"], event["End time"])
+      return "" unless start_time && end_time
 
       params = {
-        action: 'TEMPLATE',
-        text: event['Name'].to_s.strip,
+        action: "TEMPLATE",
+        text: event["Name"].to_s.strip,
         dates: "#{format_google_time(start_time)}/#{format_google_time(end_time)}",
-        details: event['Description'].to_s.strip,
-        location: event['Location'].to_s.strip,
+        details: event["Description"].to_s.strip,
+        location: event["Location"].to_s.strip,
         ctz: timezone
       }
       "https://www.google.com/calendar/render?" + URI.encode_www_form(params)
@@ -25,16 +25,16 @@ module Jekyll
 
     # Generate an ICS string for an event hash
     def event_to_ics(event)
-      start_time = parse_time(event['Start date'], event['Start time'])
-      end_time = parse_time(event['End date'], event['End time'])
+      start_time = parse_time(event["Start date"], event["Start time"])
+      end_time = parse_time(event["End date"], event["End time"])
       cal = Icalendar::Calendar.new
-      cal.append_custom_property('X-WR-CALNAME', 'PXOPulse Event')
+      cal.append_custom_property("X-WR-CALNAME", "PXOPulse Event")
       ev = Icalendar::Event.new
       ev.dtstart = start_time if start_time
       ev.dtend = end_time if end_time
-      ev.summary = event['Name'].to_s.strip
-      ev.location = event['Location'].to_s.strip
-      ev.description = event['Description'].to_s.strip
+      ev.summary = event["Name"].to_s.strip
+      ev.location = event["Location"].to_s.strip
+      ev.description = event["Description"].to_s.strip
       cal.add_event(ev)
       cal.publish
       cal.to_ical
@@ -47,12 +47,12 @@ module Jekyll
       str = date_str.to_s
       str += " #{time_str}" if time_str && !time_str.to_s.strip.empty?
       Time.parse(str)
-    rescue StandardError
+    rescue
       nil
     end
 
     def format_google_time(t)
-      t.utc.strftime('%Y%m%dT%H%M%SZ')
+      t.utc.strftime("%Y%m%dT%H%M%SZ")
     end
   end
 end

--- a/events_listing/_plugins/calendar_helpers.rb
+++ b/events_listing/_plugins/calendar_helpers.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 module Jekyll
   module CalendarHelpers
-    require 'time'
-    require 'uri'
-    require 'icalendar'
+    require "time"
+    require "uri"
+    require "icalendar"
 
     # Generate a Google Calendar URL for an event hash
     def google_calendar_url(event, timezone = 'Europe/Lisbon')

--- a/events_listing/_plugins/calendar_helpers.rb
+++ b/events_listing/_plugins/calendar_helpers.rb
@@ -10,12 +10,30 @@ module Jekyll
     def google_calendar_url(event, timezone = "Europe/Lisbon")
       start_time = parse_time(event["Start date"], event["Start time"])
       end_time = parse_time(event["End date"], event["End time"])
-      return "" unless start_time && end_time
+
+      # Handle full-day events (when both times are empty)
+      is_full_day = is_full_day_event?(event)
+
+      if is_full_day
+        start_date = parse_date_only(event["Start date"])
+        end_date = parse_date_only(event["End date"]) || start_date
+        return "" unless start_date
+
+        # For full-day events, use date format YYYYMMDD
+        dates_param = "#{format_google_date(start_date)}/#{format_google_date(end_date + 1)}"
+      else
+        return "" unless start_time
+
+        # If no end time, default to 23:59 on the same day as start time
+        end_time ||= default_end_time(start_time)
+
+        dates_param = "#{format_google_time(start_time)}/#{format_google_time(end_time)}"
+      end
 
       params = {
         action: "TEMPLATE",
         text: event["Name"].to_s.strip,
-        dates: "#{format_google_time(start_time)}/#{format_google_time(end_time)}",
+        dates: dates_param,
         details: event["Description"].to_s.strip,
         location: event["Location"].to_s.strip,
         ctz: timezone
@@ -27,11 +45,28 @@ module Jekyll
     def event_to_ics(event)
       start_time = parse_time(event["Start date"], event["Start time"])
       end_time = parse_time(event["End date"], event["End time"])
+
+      # Handle full-day events (when both times are empty)
+      is_full_day = is_full_day_event?(event)
+
       cal = Icalendar::Calendar.new
       cal.append_custom_property("X-WR-CALNAME", "PXOPulse Event")
       ev = Icalendar::Event.new
-      ev.dtstart = start_time if start_time
-      ev.dtend = end_time if end_time
+
+      if is_full_day
+        start_date = parse_date_only(event["Start date"])
+        end_date = parse_date_only(event["End date"]) || start_date
+        if start_date
+          ev.dtstart = Icalendar::Values::Date.new(start_date)
+          ev.dtend = Icalendar::Values::Date.new(end_date + 1) if end_date
+        end
+      elsif start_time
+        ev.dtstart = start_time
+        # If no end time, default to 23:59 on the same day as start time
+        end_time ||= default_end_time(start_time)
+        ev.dtend = end_time
+      end
+
       ev.summary = event["Name"].to_s.strip
       ev.location = event["Location"].to_s.strip
       ev.description = event["Description"].to_s.strip
@@ -42,17 +77,43 @@ module Jekyll
 
     private
 
+    def is_full_day_event?(event)
+      start_time = event["Start time"]
+      end_time = event["End time"]
+      (start_time.nil? || start_time.to_s.strip.empty?) &&
+        (end_time.nil? || end_time.to_s.strip.empty?)
+    end
+
+    def parse_date_only(date_str)
+      return nil if date_str.nil? || date_str.to_s.strip.empty?
+      Date.parse(date_str.to_s)
+    rescue
+      nil
+    end
+
     def parse_time(date_str, time_str)
       return nil if date_str.nil? || date_str.to_s.strip.empty?
-      str = date_str.to_s
-      str += " #{time_str}" if time_str && !time_str.to_s.strip.empty?
+      return nil if time_str.nil? || time_str.to_s.strip.empty?
+
+      str = date_str.to_s + " #{time_str}"
+      # Parse time and treat as local Lisbon time (no timezone conversion)
       Time.parse(str)
     rescue
       nil
     end
 
     def format_google_time(t)
-      t.utc.strftime("%Y%m%dT%H%M%SZ")
+      # Format time in the original timezone instead of converting to UTC
+      t.strftime("%Y%m%dT%H%M%S")
+    end
+
+    def format_google_date(d)
+      d.strftime("%Y%m%d")
+    end
+
+    def default_end_time(start_time)
+      # Set end time to 23:59 on the same day as start time
+      Time.new(start_time.year, start_time.month, start_time.day, 23, 59, 0)
     end
   end
 end

--- a/test/plugins/calendar_helpers_test.rb
+++ b/test/plugins/calendar_helpers_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "minitest/autorun"
 
 # Mock Liquid to avoid dependency issues in tests

--- a/test/plugins/calendar_helpers_test.rb
+++ b/test/plugins/calendar_helpers_test.rb
@@ -38,4 +38,379 @@ class TestCalendarHelpers < Minitest::Test
     assert_includes ics, "BEGIN:VEVENT"
     assert_includes ics, "SUMMARY:Test Event"
   end
+
+  # Full-day event tests
+  def test_is_full_day_event_with_no_times
+    full_day_event = {
+      "Name" => "Full Day Event",
+      "Start date" => "2025-12-01",
+      "Start time" => "",
+      "End date" => "2025-12-01",
+      "End time" => "",
+      "Description" => "All day event",
+      "Location" => "Location"
+    }
+
+    assert send(:is_full_day_event?, full_day_event), "Should detect full-day event when times are empty"
+  end
+
+  def test_is_full_day_event_with_nil_times
+    full_day_event = {
+      "Name" => "Full Day Event",
+      "Start date" => "2025-12-01",
+      "Start time" => nil,
+      "End date" => "2025-12-01",
+      "End time" => nil,
+      "Description" => "All day event",
+      "Location" => "Location"
+    }
+
+    assert send(:is_full_day_event?, full_day_event), "Should detect full-day event when times are nil"
+  end
+
+  def test_is_not_full_day_event_with_start_time
+    timed_event = {
+      "Name" => "Timed Event",
+      "Start date" => "2025-12-01",
+      "Start time" => "10:00",
+      "End date" => "2025-12-01",
+      "End time" => "",
+      "Description" => "Timed event",
+      "Location" => "Location"
+    }
+
+    refute send(:is_full_day_event?, timed_event), "Should not detect full-day event when start time exists"
+  end
+
+  def test_is_not_full_day_event_with_end_time
+    timed_event = {
+      "Name" => "Timed Event",
+      "Start date" => "2025-12-01",
+      "Start time" => "",
+      "End date" => "2025-12-01",
+      "End time" => "12:00",
+      "Description" => "Timed event",
+      "Location" => "Location"
+    }
+
+    refute send(:is_full_day_event?, timed_event), "Should not detect full-day event when end time exists"
+  end
+
+  def test_google_calendar_url_full_day_single_day
+    full_day_event = {
+      "Name" => "Full Day Event",
+      "Start date" => "2025-12-01",
+      "Start time" => "",
+      "End date" => "2025-12-01",
+      "End time" => "",
+      "Description" => "All day event",
+      "Location" => "Location"
+    }
+
+    url = google_calendar_url(full_day_event)
+    assert url.start_with?("https://www.google.com/calendar/render?")
+    assert_includes url, "20251201%2F20251202", "Should use date format and add 1 day to end"
+    assert_includes url, "Full+Day+Event"
+  end
+
+  def test_google_calendar_url_full_day_multi_day
+    full_day_event = {
+      "Name" => "Multi Day Event",
+      "Start date" => "2025-12-01",
+      "Start time" => "",
+      "End date" => "2025-12-03",
+      "End time" => "",
+      "Description" => "Multi day event",
+      "Location" => "Location"
+    }
+
+    url = google_calendar_url(full_day_event)
+    assert url.start_with?("https://www.google.com/calendar/render?")
+    assert_includes url, "20251201%2F20251204", "Should use date format and add 1 day to end date"
+    assert_includes url, "Multi+Day+Event"
+  end
+
+  def test_google_calendar_url_full_day_no_end_date
+    full_day_event = {
+      "Name" => "Single Day Event",
+      "Start date" => "2025-12-01",
+      "Start time" => "",
+      "End date" => "",
+      "End time" => "",
+      "Description" => "Single day event",
+      "Location" => "Location"
+    }
+
+    url = google_calendar_url(full_day_event)
+    assert url.start_with?("https://www.google.com/calendar/render?")
+    assert_includes url, "20251201%2F20251202", "Should use start date for both start and end when no end date"
+  end
+
+  def test_event_to_ics_full_day_single_day
+    full_day_event = {
+      "Name" => "Full Day Event",
+      "Start date" => "2025-12-01",
+      "Start time" => "",
+      "End date" => "2025-12-01",
+      "End time" => "",
+      "Description" => "All day event",
+      "Location" => "Location"
+    }
+
+    ics = event_to_ics(full_day_event)
+    assert_includes ics, "BEGIN:VEVENT"
+    assert_includes ics, "SUMMARY:Full Day Event"
+    assert_includes ics, "DTSTART;VALUE=DATE:20251201"
+    assert_includes ics, "DTEND;VALUE=DATE:20251202", "Should add 1 day to end date for full-day events"
+  end
+
+  def test_event_to_ics_full_day_multi_day
+    full_day_event = {
+      "Name" => "Multi Day Event",
+      "Start date" => "2025-12-01",
+      "Start time" => "",
+      "End date" => "2025-12-03",
+      "End time" => "",
+      "Description" => "Multi day event",
+      "Location" => "Location"
+    }
+
+    ics = event_to_ics(full_day_event)
+    assert_includes ics, "BEGIN:VEVENT"
+    assert_includes ics, "SUMMARY:Multi Day Event"
+    assert_includes ics, "DTSTART;VALUE=DATE:20251201"
+    assert_includes ics, "DTEND;VALUE=DATE:20251204", "Should add 1 day to end date for multi-day events"
+  end
+
+  def test_event_to_ics_timed_event_format
+    ics = event_to_ics(@event)
+    assert_includes ics, "BEGIN:VEVENT"
+    assert_includes ics, "SUMMARY:Test Event"
+    # Should contain time-based format, not VALUE=DATE format
+    refute_includes ics, "VALUE=DATE"
+    assert_includes ics, "DTSTART:"
+    assert_includes ics, "DTEND:"
+  end
+
+  def test_parse_date_only_valid_date
+    date = send(:parse_date_only, "2025-12-01")
+    assert_equal Date.new(2025, 12, 1), date
+  end
+
+  def test_parse_date_only_invalid_date
+    date = send(:parse_date_only, "invalid-date")
+    assert_nil date
+  end
+
+  def test_parse_date_only_empty_string
+    date = send(:parse_date_only, "")
+    assert_nil date
+  end
+
+  def test_parse_date_only_nil
+    date = send(:parse_date_only, nil)
+    assert_nil date
+  end
+
+  def test_format_google_date
+    date = Date.new(2025, 12, 1)
+    formatted = send(:format_google_date, date)
+    assert_equal "20251201", formatted
+  end
+
+  # Edge case tests
+  def test_full_day_event_with_whitespace_times
+    full_day_event = {
+      "Name" => "Whitespace Event",
+      "Start date" => "2025-12-01",
+      "Start time" => "   ",
+      "End date" => "2025-12-01",
+      "End time" => "  ",
+      "Description" => "Event with whitespace times",
+      "Location" => "Location"
+    }
+
+    assert send(:is_full_day_event?, full_day_event), "Should detect full-day event when times are whitespace"
+  end
+
+  def test_google_calendar_url_returns_empty_for_invalid_full_day_event
+    invalid_event = {
+      "Name" => "Invalid Event",
+      "Start date" => "",
+      "Start time" => "",
+      "End date" => "",
+      "End time" => "",
+      "Description" => "Invalid event",
+      "Location" => "Location"
+    }
+
+    url = google_calendar_url(invalid_event)
+    assert_equal "", url, "Should return empty string for event with no start date"
+  end
+
+  def test_event_to_ics_full_day_with_no_start_date
+    invalid_event = {
+      "Name" => "Invalid Event",
+      "Start date" => "",
+      "Start time" => "",
+      "End date" => "",
+      "End time" => "",
+      "Description" => "Invalid event",
+      "Location" => "Location"
+    }
+
+    ics = event_to_ics(invalid_event)
+    assert_includes ics, "BEGIN:VEVENT"
+    assert_includes ics, "SUMMARY:Invalid Event"
+    # Should not include DTSTART or DTEND for invalid dates
+    refute_includes ics, "DTSTART"
+    refute_includes ics, "DTEND"
+  end
+
+  # Timezone tests
+  def test_parse_time_creates_valid_time
+    time = send(:parse_time, "2025-12-01", "10:00")
+    refute_nil time
+    # Should parse the time correctly
+    assert_equal 10, time.hour
+    assert_equal 0, time.min
+  end
+
+  def test_format_google_time_does_not_convert_to_utc
+    # Create a time
+    time = send(:parse_time, "2025-12-01", "10:00")
+    formatted = send(:format_google_time, time)
+    # Should preserve the local time, not convert to UTC
+    assert_equal "20251201T100000", formatted
+    # Should not have 'Z' suffix which indicates UTC
+    refute_includes formatted, "Z"
+  end
+
+  def test_google_calendar_url_preserves_timezone
+    url = google_calendar_url(@event)
+    # Should contain the original times without UTC conversion
+    assert_includes url, "20251201T100000%2F20251201T120000"
+    # Should not contain 'Z' which would indicate UTC
+    refute_includes url, "Z"
+  end
+
+  # Default end time tests
+  def test_google_calendar_url_with_start_time_no_end_time
+    event_no_end = {
+      "Name" => "Event No End",
+      "Start date" => "2025-12-01",
+      "Start time" => "10:00",
+      "End date" => "",
+      "End time" => "",
+      "Description" => "Event with no end time",
+      "Location" => "Location"
+    }
+
+    url = google_calendar_url(event_no_end)
+    assert url.start_with?("https://www.google.com/calendar/render?")
+    # Should default end time to 23:59 on the same day
+    assert_includes url, "20251201T100000%2F20251201T235900"
+    assert_includes url, "Event+No+End"
+  end
+
+  def test_event_to_ics_with_start_time_no_end_time
+    event_no_end = {
+      "Name" => "Event No End",
+      "Start date" => "2025-12-01",
+      "Start time" => "10:00",
+      "End date" => "",
+      "End time" => "",
+      "Description" => "Event with no end time",
+      "Location" => "Location"
+    }
+
+    ics = event_to_ics(event_no_end)
+    assert_includes ics, "BEGIN:VEVENT"
+    assert_includes ics, "SUMMARY:Event No End"
+    assert_includes ics, "DTSTART:"
+    assert_includes ics, "DTEND:"
+    # Should contain times, not VALUE=DATE format since it's not a full-day event
+    refute_includes ics, "VALUE=DATE"
+  end
+
+  def test_default_end_time_helper
+    start_time = Time.new(2025, 12, 1, 10, 30, 0)
+    end_time = send(:default_end_time, start_time)
+
+    assert_equal 2025, end_time.year
+    assert_equal 12, end_time.month
+    assert_equal 1, end_time.day
+    assert_equal 23, end_time.hour
+    assert_equal 59, end_time.min
+    assert_equal 0, end_time.sec
+  end
+
+  def test_google_calendar_url_with_start_time_and_nil_end_time
+    event_nil_end = {
+      "Name" => "Event Nil End",
+      "Start date" => "2025-12-01",
+      "Start time" => "14:30",
+      "End date" => "2025-12-01",
+      "End time" => nil,
+      "Description" => "Event with nil end time",
+      "Location" => "Location"
+    }
+
+    url = google_calendar_url(event_nil_end)
+    assert url.start_with?("https://www.google.com/calendar/render?")
+    # Should default end time to 23:59 on the same day
+    assert_includes url, "20251201T143000%2F20251201T235900"
+  end
+
+  def test_google_calendar_url_no_start_time_returns_empty
+    event_no_start = {
+      "Name" => "Event No Start",
+      "Start date" => "2025-12-01",
+      "Start time" => "",
+      "End date" => "2025-12-01",
+      "End time" => "18:00",
+      "Description" => "Event with no start time",
+      "Location" => "Location"
+    }
+
+    url = google_calendar_url(event_no_start)
+    assert_equal "", url, "Should return empty string when no start time"
+  end
+
+  def test_event_to_ics_with_start_time_no_end_time_afternoon
+    event_afternoon = {
+      "Name" => "Afternoon Event",
+      "Start date" => "2025-12-01",
+      "Start time" => "15:30",
+      "End date" => "",
+      "End time" => "",
+      "Description" => "Afternoon event with no end time",
+      "Location" => "Location"
+    }
+
+    ics = event_to_ics(event_afternoon)
+    assert_includes ics, "BEGIN:VEVENT"
+    assert_includes ics, "SUMMARY:Afternoon Event"
+    # Should have both start and end times
+    assert_includes ics, "DTSTART:"
+    assert_includes ics, "DTEND:"
+  end
+
+  def test_default_end_time_different_start_times
+    # Test with morning start time
+    morning_start = Time.new(2025, 12, 1, 8, 15, 0)
+    morning_end = send(:default_end_time, morning_start)
+    assert_equal 23, morning_end.hour
+    assert_equal 59, morning_end.min
+
+    # Test with evening start time
+    evening_start = Time.new(2025, 12, 1, 20, 45, 0)
+    evening_end = send(:default_end_time, evening_start)
+    assert_equal 23, evening_end.hour
+    assert_equal 59, evening_end.min
+
+    # Both should be on the same day as start time
+    assert_equal morning_start.day, morning_end.day
+    assert_equal evening_start.day, evening_end.day
+  end
 end

--- a/test/plugins/calendar_helpers_test.rb
+++ b/test/plugins/calendar_helpers_test.rb
@@ -5,7 +5,8 @@ require "minitest/autorun"
 # Mock Liquid to avoid dependency issues in tests
 module Liquid
   class Template
-    def self.register_filter(filter_module); end
+    def self.register_filter(filter_module)
+    end
   end
 end
 

--- a/test/plugins/calendar_helpers_test.rb
+++ b/test/plugins/calendar_helpers_test.rb
@@ -1,0 +1,38 @@
+require "minitest/autorun"
+
+# Mock Liquid to avoid dependency issues in tests
+module Liquid
+  class Template
+    def self.register_filter(filter_module); end
+  end
+end
+
+require_relative "../../events_listing/_plugins/calendar_helpers"
+
+class TestCalendarHelpers < Minitest::Test
+  include Jekyll::CalendarHelpers
+
+  def setup
+    @event = {
+      "Name" => "Test Event",
+      "Start date" => "2025-12-01",
+      "Start time" => "10:00",
+      "End date" => "2025-12-01",
+      "End time" => "12:00",
+      "Description" => "Desc",
+      "Location" => "Loc"
+    }
+  end
+
+  def test_google_calendar_url_contains_event_name
+    url = google_calendar_url(@event)
+    assert url.start_with?("https://www.google.com/calendar/render?")
+    assert_includes url, "Test+Event"
+  end
+
+  def test_event_to_ics_contains_summary
+    ics = event_to_ics(@event)
+    assert_includes ics, "BEGIN:VEVENT"
+    assert_includes ics, "SUMMARY:Test Event"
+  end
+end


### PR DESCRIPTION
## Summary
- add calendar helper plugin for Google/Apple calendar links
- expose new calendar options on event page
- test calendar helpers

## Testing
- `bundle install` *(fails: 403 Forbidden)*
- `bundle exec rake` *(fails: jekyll-seo-tag not checked out)*

------
https://chatgpt.com/codex/tasks/task_e_6841aabd8ad4832fba75a9a44ab27fb4