### PR TITLE
Adjust calendar week start to Sunday

### DIFF
--- a/events_listing/assets/js/calendar.js
+++ b/events_listing/assets/js/calendar.js
@@ -116,7 +116,7 @@ document.addEventListener('DOMContentLoaded', () => {
     titleEl.textContent = new Date(year, month).toLocaleString('pt-PT', {month:'long', year:'numeric'});
     calendarEl.innerHTML = '';
 
-    const daysOfWeek = ['Sem', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sáb', 'Dom'];
+    const daysOfWeek = ['Sem', 'Dom', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sáb'];
     daysOfWeek.forEach(dayName => {
       const header = document.createElement('div');
       header.className = 'py-2 font-semibold border-b border-gray-200';
@@ -125,7 +125,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     const firstDay = new Date(year, month, 1);
-    const offset = (firstDay.getDay() + 6) % 7; // monday start
+    const offset = firstDay.getDay(); // domingo start
     const startDate = new Date(year, month, 1 - offset);
 
     for (let week = 0; week < 6; week++) {
@@ -237,16 +237,14 @@ document.addEventListener('DOMContentLoaded', () => {
   function startOfWeek(date) {
     const d = new Date(date);
     const day = d.getDay();
-    const diff = (day === 0 ? -6 : 1) - day;
-    d.setDate(d.getDate() + diff);
+    d.setDate(d.getDate() - day); // domingo start
     return formatISO(d);
   }
 
   function endOfWeek(date) {
     const start = new Date(date);
     const day = start.getDay();
-    const diff = (day === 0 ? -6 : 1) - day + 6;
-    start.setDate(start.getDate() + diff);
+    start.setDate(start.getDate() + (6 - day)); // domingo start
     return formatISO(start);
   }
 


### PR DESCRIPTION
## Summary
- adjust day headers to start from Sunday
- update week calculations to assume Sunday as first day

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_6843fa107fcc832fb3017d56d8ebd3d4