### PR TITLE
Fix offline page fallback in service worker

### DIFF
--- a/events_listing/sw.js.liquid
+++ b/events_listing/sw.js.liquid
@@ -145,7 +145,7 @@ if (workbox) {
 
     // Return offline page for navigation requests
     if (request.mode === 'navigate') {
-      return caches.match(FALLBACK_HTML_URL);
+      return workbox.precaching.matchPrecache(FALLBACK_HTML_URL);
     }
 
     // Return offline image for image requests


### PR DESCRIPTION
## Summary
- use `workbox.precaching.matchPrecache` in the catch handler so offline
  navigation fetches `/offline.html` even when revisioned

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_684404b6dc08832fb344e419110ac69c