### PR TITLE
Update service worker caching

### DIFF
--- a/events_listing/_layouts/default.html
+++ b/events_listing/_layouts/default.html
@@ -40,7 +40,7 @@
     <script>
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', () => {
-          navigator.serviceWorker.register('/sw.js')
+          navigator.serviceWorker.register('/sw.js', { updateViaCache: 'none' })
             .then((registration) => {
               console.log('Service Worker registered successfully:', registration.scope);
 

--- a/events_listing/sw.js.liquid
+++ b/events_listing/sw.js.liquid
@@ -39,6 +39,7 @@ if (workbox) {
   workbox.navigationPreload.enable();
 
   workbox.precaching.precacheAndRoute(precacheManifest);
+  workbox.precaching.cleanupOutdatedCaches();
 
   // Set up offline fallback page reference
   const FALLBACK_HTML_URL = '/offline.html';
@@ -59,6 +60,12 @@ if (workbox) {
     );
   } else {
     // Production strategies with modern best practices
+
+    // Ensure the service worker script is always fetched from the network
+    workbox.routing.registerRoute(
+      ({ url }) => url.pathname === '/sw.js',
+      new workbox.strategies.NetworkOnly()
+    );
 
     // Stale While Revalidate for HTML pages (better UX than NetworkFirst)
     workbox.routing.registerRoute(
@@ -81,6 +88,7 @@ if (workbox) {
     // Cache First for static assets with longer expiration
     workbox.routing.registerRoute(
       ({ request, url }) => {
+        if (url.pathname === '/sw.js') return false;
         return url.pathname.startsWith('/assets/') ||
                request.destination === 'style' ||
                request.destination === 'script' ||


### PR DESCRIPTION
## Summary
- ensure `sw.js` is fetched from the network and not cached
- cleanup outdated caches after precache
- register the service worker with `updateViaCache: 'none'`

## Testing
- `rake test`
- ❌ `jekyll build` *(skipped: "Do not start jekyll build / server. I've already done that in other shell. Its launched with docker-compose" in `AGENTS.md`)*

------
https://chatgpt.com/codex/tasks/task_e_68440a1bc198832fb648b7bfc0692a74