### PR TITLE
Feature: Add ruby_llm gem and image analysis utility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,5 @@ GOOGLE_SPREADSHEET_ID=your-spreadsheet-id
 EVENTS_SHEET_RANGE=Events!A:O
 GH_REPO=your-github-repo
 GH_TOKEN=your-github-token
+
+GEMINI_API_KEY=your-gemini-api-key

--- a/Gemfile
+++ b/Gemfile
@@ -49,3 +49,5 @@ gem "google-apis-sheets_v4", "~> 0.44.0"
 
 # Image processing gem
 gem "mini_magick", "~> 5.2"
+
+gem "ruby_llm", "~> 1.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,13 +68,18 @@ GEM
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
+    event_stream_parser (1.0.0)
     eventmachine (1.2.7)
     faraday (2.13.1)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
+    faraday-multipart (1.1.0)
+      multipart-post (~> 2.0)
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
+    faraday-retry (2.3.1)
+      faraday (~> 2.0)
     ffi (1.17.2-x86_64-linux-gnu)
     forwardable-extended (2.6.0)
     google-apis-core (0.18.0)
@@ -162,6 +167,7 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
+    marcel (1.0.4)
     mercenary (0.4.0)
     mini_magick (5.2.0)
       benchmark
@@ -169,6 +175,7 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.5)
     multi_json (1.15.0)
+    multipart-post (2.4.1)
     mustermann (3.0.3)
       ruby2_keywords (~> 0.0.1)
     mutex_m (0.3.0)
@@ -252,6 +259,15 @@ GEM
       sorbet-runtime (>= 0.5.10782)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    ruby_llm (1.3.0)
+      base64
+      event_stream_parser (~> 1)
+      faraday (>= 1.10.0)
+      faraday-multipart (>= 1)
+      faraday-net_http (>= 1)
+      faraday-retry (>= 1)
+      marcel (~> 1.0)
+      zeitwerk (~> 2)
     safe_yaml (1.0.5)
     sass-embedded (1.89.0-x86_64-linux-gnu)
       google-protobuf (~> 4.31)
@@ -328,6 +344,7 @@ DEPENDENCIES
   rackup (~> 2.2)
   rerun
   ruby-lsp
+  ruby_llm (~> 1.3)
   simplecov
   sinatra
   standard

--- a/bin/test_llm
+++ b/bin/test_llm
@@ -1,0 +1,65 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# filepath: /home/omen/personal/ps_events/bin/test_llm
+
+require "bundler/setup"
+require "ruby_llm"
+require "pathname"
+
+# Configuration
+RubyLLM.configure do |config|
+  config.gemini_api_key = ENV.fetch("GEMINI_API_KEY", nil)
+  # config.log_level = :debug  # Log level (:debug, :info, :warn)
+end
+
+# CLI argument validation
+if ARGV.length != 1
+  puts "Usage: #{$0} <image_path>"
+  puts "Example: #{$0} ./my_image.jpg"
+  exit 1
+end
+
+image_path = ARGV[0]
+
+# Validate image file exists
+unless File.exist?(image_path)
+  puts "Error: Image file '#{image_path}' does not exist."
+  exit 1
+end
+
+begin
+  puts "Analyzing image: #{image_path}"
+  puts "Using Gemini 2.5 Flash Preview model..."
+  puts
+
+  # Create chat instance with the specified model
+  chat = RubyLLM.chat(model: "gemini-2.5-flash-preview-05-20")
+
+  # Ask about text in the image
+  prompt = "Please analyze this image and extract all the text you can read. " \
+           "If there's no text in the image, describe what you see. " \
+           "Respond in English."
+
+  response = chat.ask(prompt, with: image_path)
+
+  puts "Analysis result:"
+  puts "=" * 50
+  puts response.content
+  puts "=" * 50
+  puts
+  puts "Model used: #{response.model_id}"
+  puts "Input tokens: #{response.input_tokens}" if response.input_tokens
+  puts "Output tokens: #{response.output_tokens}" if response.output_tokens
+rescue => e
+  puts "Error processing image: #{e.message}"
+  puts "Error details: #{e.class}"
+
+  if e.message.include?("API_KEY")
+    puts
+    puts "Make sure the GEMINI_API_KEY environment variable is set."
+    puts "Export GEMINI_API_KEY=<your_api_key>"
+  end
+
+  exit 1
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,14 @@ x-app: &x-app
 services:
   app:
     <<: *x-app
+    env_file:
+      - .env
+    command:
+      - sh
+      - -c
+      - sleep infinity
+  jekyll:
+    <<: *x-app
     ports:
       - "127.0.0.1:4000:4000"
       - "127.0.0.1:35729:35729"


### PR DESCRIPTION
Installs the `ruby_llm` gem and adds a placeholder for the `GEMINI_API_KEY` in `.env.example`.

Includes a new executable script `bin/test_llm` to demonstrate image analysis using the Gemini API via the `ruby_llm` gem. The script takes an image path as an argument and attempts to extract text or describe the image.

Updates `docker-compose.yml` to introduce a dedicated `app` service for running general utilities (like the LLM script) with environment variables loaded, separating it from the Jekyll build process (now in the `jekyll` service).