### PR TITLE
Update service worker lifecycle handling

### DIFF
--- a/events_listing/sw.js.liquid
+++ b/events_listing/sw.js.liquid
@@ -167,9 +167,14 @@ if (workbox) {
     return Response.error();
   });
 
-  // Claim clients immediately and skip waiting
-  workbox.core.clientsClaim();
-  self.skipWaiting();
+  // Handle install and activate lifecycle events
+  self.addEventListener('install', (event) => {
+    event.waitUntil(self.skipWaiting());
+  });
+
+  self.addEventListener('activate', (event) => {
+    event.waitUntil(self.clients.claim());
+  });
 
 } else {
   console.error('Workbox could not be loaded. Falling back to basic implementation.');
@@ -179,9 +184,10 @@ if (workbox) {
 
   self.addEventListener('install', (event) => {
     event.waitUntil(
-      caches.open(CACHE_NAME).then((cache) => {
-        return cache.addAll(['/offline.html']);
-      })
+      Promise.all([
+        self.skipWaiting(),
+        caches.open(CACHE_NAME).then((cache) => cache.addAll(['/offline.html']))
+      ])
     );
   });
 


### PR DESCRIPTION
## Summary
- ensure service worker lifecycle events call `skipWaiting()` and `clients.claim()` within their respective event handlers
- wait for these lifecycle promises so the worker activates immediately and takes control across both Workbox and fallback paths

## Testing
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_684404b78e00832fa9711aba88d78347