### PR TITLE
Improve mobile upload compatibility

### DIFF
--- a/events_listing/add_event.html
+++ b/events_listing/add_event.html
@@ -266,7 +266,7 @@ sitemap: false
         accept="image/*"
         class="form-input file-input-button"
       />
-      <p class="form-help">Carregue uma imagem para o seu evento (opcional). Formatos suportados: JPEG, PNG, GIF, WebP, BMP, TIFF. Tamanho máximo: 10MB.</p>
+      <p class="form-help">Carregue uma imagem para o seu evento (opcional). Formatos suportados: JPEG, PNG, GIF, WebP, BMP, TIFF, HEIC. Tamanho máximo: 10MB.</p>
       <div id="image-preview" class="mt-3 hidden">
         <img id="preview-img" src="" alt="Pré-visualização da imagem" class="max-w-xs max-h-48 rounded-lg border border-gray-200" />
         <button type="button" id="remove-image" class="mt-2 text-sm text-red-600 hover:text-red-800">Remover imagem</button>
@@ -471,7 +471,7 @@ sitemap: false
         }
 
         // Validate file type
-        const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp', 'image/bmp', 'image/tiff'];
+        const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp', 'image/bmp', 'image/tiff', 'image/heic', 'image/heif'];
         if (!allowedTypes.includes(file.type)) {
           showToast('Tipo de ficheiro inválido. Por favor, carregue um ficheiro de imagem.', 'error');
           imageInput.value = '';

--- a/lib/server/image_service.rb
+++ b/lib/server/image_service.rb
@@ -72,13 +72,14 @@ class ImageService
     end
 
     # Check MIME type
-    allowed_types = %w[
-      image/jpeg image/jpg image/png image/gif
-      image/webp image/bmp image/tiff image/tif
-    ]
+      allowed_types = %w[
+        image/jpeg image/jpg image/png image/gif
+        image/webp image/bmp image/tiff image/tif
+        image/heic image/heif
+      ]
 
-    unless allowed_types.include?(uploaded_file[:type])
-      return "Invalid file type. Please upload an image file (JPEG, PNG, GIF, WebP, BMP, or TIFF)."
+      unless allowed_types.include?(uploaded_file[:type])
+        return "Invalid file type. Please upload an image file (JPEG, PNG, GIF, WebP, BMP, TIFF ou HEIC)."
     end
 
     nil # No errors


### PR DESCRIPTION
## Summary
- support uploading HEIC images in JS validation and backend
- clarify supported file types in the add event form

## Testing
- `rake test`

------
https://chatgpt.com/codex/tasks/task_e_68447c7b17fc832f9eda702ce72bf629