### PR TITLE
Clean old caches during SW activate

### DIFF
--- a/events_listing/sw.js.liquid
+++ b/events_listing/sw.js.liquid
@@ -204,14 +204,8 @@ if (workbox) {
       (async () => {
         const expectedSuffix = '{% cache_bust_param %}';
         const keys = await caches.keys();
-        await Promise.all(
-          keys.map((cacheName) => {
-            if (!cacheName.includes(expectedSuffix)) {
-              return caches.delete(cacheName);
-            }
-            return Promise.resolve();
-          })
-        );
+        const cachesToDelete = keys.filter((cacheName) => !cacheName.includes(expectedSuffix));
+        await Promise.all(cachesToDelete.map((cacheName) => caches.delete(cacheName)));
         await self.clients.claim();
       })()
     );

--- a/events_listing/sw.js.liquid
+++ b/events_listing/sw.js.liquid
@@ -192,12 +192,29 @@ if (workbox) {
   });
 
   // Handle install and activate lifecycle events
+  // During activation we iterate over existing caches and
+  // remove any that don't contain the current {% cache_bust_param %}.
   self.addEventListener('install', () => {
     self.skipWaiting();
   });
 
   self.addEventListener('activate', (event) => {
-    event.waitUntil(self.clients.claim());
+    // Remove caches that don't include the current commit-based suffix
+    event.waitUntil(
+      (async () => {
+        const expectedSuffix = '{% cache_bust_param %}';
+        const keys = await caches.keys();
+        await Promise.all(
+          keys.map((cacheName) => {
+            if (!cacheName.includes(expectedSuffix)) {
+              return caches.delete(cacheName);
+            }
+            return Promise.resolve();
+          })
+        );
+        await self.clients.claim();
+      })()
+    );
   });
 
 } else {
@@ -225,7 +242,24 @@ if (workbox) {
     }
   });
 
+  // During activation we remove any caches that don't include the
+  // current {% cache_bust_param %}.
   self.addEventListener('activate', (event) => {
-    event.waitUntil(self.clients.claim());
+    // Remove caches that don't include the current commit-based suffix
+    event.waitUntil(
+      (async () => {
+        const expectedSuffix = '{% cache_bust_param %}';
+        const keys = await caches.keys();
+        await Promise.all(
+          keys.map((cacheName) => {
+            if (!cacheName.includes(expectedSuffix)) {
+              return caches.delete(cacheName);
+            }
+            return Promise.resolve();
+          })
+        );
+        await self.clients.claim();
+      })()
+    );
   });
 }


### PR DESCRIPTION
## Summary
- clean up outdated caches during the `activate` event
- document cache cleanup logic in `sw.js.liquid`

## Testing
- `rake test`

------
https://chatgpt.com/codex/tasks/task_e_68447cc19528832fa5f3477d525f637c