### PR TITLE
Add event image upload endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,4 +8,8 @@ EVENTS_SHEET_RANGE=Events!A:O
 GH_REPO=your-github-repo
 GH_TOKEN=your-github-token
 
+
+# Host address for the backend server
+BACKEND_HOST=http://localhost:4001
+
 GEMINI_API_KEY=your-gemini-api-key

--- a/.github/workflows/jekyll_site.yml
+++ b/.github/workflows/jekyll_site.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Build Jekyll site
-        run: docker compose run -e JEKYLL_ENV=production -e FORM_ADD_EVENT_POST_ENDPOINT=${{ secrets.FORM_ADD_EVENT_POST_ENDPOINT }} -e COMMIT_SHA=${{ github.sha }} app jekyll build --source /app/events_listing --destination /app/_site --baseurl "${{ steps.pages.outputs.base_path }}"
+        run: docker compose run -e JEKYLL_ENV=production -e BACKEND_HOST=${{ secrets.BACKEND_HOST }} -e COMMIT_SHA=${{ github.sha }} app jekyll build --source /app/events_listing --destination /app/_site --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           COMPOSE_FILE: docker-compose.ci.yml
           COMMIT_SHA: ${{ github.sha }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - "127.0.0.1:4000:4000"
       - "127.0.0.1:35729:35729"
     environment:
-      FORM_ADD_EVENT_POST_ENDPOINT: "http://localhost:4001/add_event"
+      BACKEND_HOST: "http://localhost:4001"
       JEKYLL_ENV: development
     command:
       - rerun

--- a/events_listing/add_event.html
+++ b/events_listing/add_event.html
@@ -62,7 +62,7 @@ sitemap: false
     </div>
   </div>
 
-  <form action="{{ site.env.FORM_ADD_EVENT_POST_ENDPOINT }}" method="POST" enctype="multipart/form-data" class="space-y-6">
+  <form action="{{ site.env.BACKEND_HOST }}/add_event" method="POST" enctype="multipart/form-data" class="space-y-6">
 
     <!-- Hidden field for Google token -->
     <input type="hidden" name="google_token" id="google_token" value="">

--- a/events_listing/event_image.html
+++ b/events_listing/event_image.html
@@ -1,0 +1,79 @@
+---
+layout: default
+title: "Carregar Imagem"
+permalink: /event_image/
+sitemap: false
+---
+
+<section id="image-upload" class="max-w-xl mx-auto py-8">
+  <h1 class="page-title">Carregar Imagem do Evento</h1>
+  {% unless jekyll.environment == 'development' %}
+  <div id="google-area" class="mb-6 p-6 bg-white rounded-lg shadow-lg border-b-4 border-buttons">
+    <div id="google-signin"></div>
+    <div id="google-user" class="hidden">
+      <p class="form-label">Verificado como <span id="user-email"></span></p>
+    </div>
+  </div>
+  {% endunless %}
+  <form action="{{ site.env.BACKEND_HOST }}/event_image" method="POST" enctype="multipart/form-data" class="space-y-6">
+    <input type="hidden" name="google_token" id="google_token" value="">
+    <div>
+      <label for="event_image" class="form-label">Imagem <span class="text-red-500">*</span></label>
+      <input type="file" name="event_image" id="event_image" required class="form-input" />
+    </div>
+    <button type="submit" id="submit-btn" class="btn-primary">Enviar</button>
+  </form>
+  <div id="toast-container" class="fixed inset-x-0 bottom-5 flex flex-col items-center space-y-3 z-50"></div>
+</section>
+
+<script src="https://accounts.google.com/gsi/client" async defer></script>
+<script>
+{% unless jekyll.environment == 'development' %}
+  let googleCredential = null;
+  function initGoogle() {
+    if (typeof google !== 'undefined') {
+      google.accounts.id.initialize({
+        client_id: '730968670456-4kvre8am1isuqe3dbmdqs8845ntog6cq.apps.googleusercontent.com',
+        callback: handleGoogle
+      });
+      google.accounts.id.renderButton(
+        document.getElementById('google-signin'),
+        { theme: 'outline', size: 'large', text: 'signin_with', locale: 'pt-PT' }
+      );
+    } else {
+      setTimeout(initGoogle, 100);
+    }
+  }
+  function handleGoogle(res) {
+    googleCredential = res.credential;
+    const payload = JSON.parse(atob(res.credential.split('.')[1]));
+    document.getElementById('user-email').textContent = payload.email;
+    document.getElementById('google_token').value = res.credential;
+    document.getElementById('google-user').classList.remove('hidden');
+    document.getElementById('google-signin').classList.add('hidden');
+  }
+  document.addEventListener('DOMContentLoaded', initGoogle);
+{% endunless %}
+
+  document.querySelector('#image-upload form').addEventListener('submit', async (e) => {
+{% unless jekyll.environment == 'development' %}
+    if (!googleCredential || !document.getElementById('google_token').value) {
+      e.preventDefault();
+      showToast('É necessário iniciar sessão com o Google.', 'error');
+      return;
+    }
+{% endunless %}
+  });
+
+  function showToast(message, type = 'success') {
+    const bg = type === 'success' ? 'bg-green-500' : 'bg-red-500';
+    const toast = document.createElement('div');
+    toast.className = `${bg} text-white px-4 py-2 rounded shadow transition-opacity duration-500`;
+    toast.textContent = message;
+    document.getElementById('toast-container').appendChild(toast);
+    setTimeout(() => {
+      toast.classList.add('opacity-0');
+      toast.addEventListener('transitionend', () => toast.remove());
+    }, 3000);
+  }
+</script>

--- a/events_listing/event_image.html
+++ b/events_listing/event_image.html
@@ -24,6 +24,15 @@ sitemap: false
     <button type="submit" id="submit-btn" class="btn-primary">Enviar</button>
   </form>
   <div id="toast-container" class="fixed inset-x-0 bottom-5 flex flex-col items-center space-y-3 z-50"></div>
+
+  <div id="result-modal" class="hidden fixed inset-0 z-50 flex items-center justify-center">
+    <div class="absolute inset-0 bg-black/50"></div>
+    <div class="relative bg-white rounded-lg shadow-lg p-6 space-y-4 w-11/12 max-w-md">
+      <p class="font-semibold">Imagem carregada</p>
+      <input type="text" id="image-url" readonly class="form-input" />
+      <button id="close-modal" class="navigation-button w-full">Fechar</button>
+    </div>
+  </div>
 </section>
 
 <script src="https://accounts.google.com/gsi/client" async defer></script>
@@ -55,14 +64,43 @@ sitemap: false
   document.addEventListener('DOMContentLoaded', initGoogle);
 {% endunless %}
 
-  document.querySelector('#image-upload form').addEventListener('submit', async (e) => {
+  const form = document.querySelector('#image-upload form');
+  const modal = document.getElementById('result-modal');
+  const imageUrlInput = document.getElementById('image-url');
+  const closeModalBtn = document.getElementById('close-modal');
+
+  closeModalBtn.addEventListener('click', () => modal.classList.add('hidden'));
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
 {% unless jekyll.environment == 'development' %}
     if (!googleCredential || !document.getElementById('google_token').value) {
-      e.preventDefault();
       showToast('É necessário iniciar sessão com o Google.', 'error');
       return;
     }
 {% endunless %}
+
+    const data = new FormData(form);
+    try {
+      const response = await fetch(form.action, { method: 'POST', body: data });
+      if (!response.ok) {
+        let msg = `Erro ${response.status}`;
+        try { const r = await response.json(); msg = r.message || msg; } catch (_) {}
+        showToast(msg, 'error');
+        return;
+      }
+      const result = await response.json();
+      if (result.status === 'ok') {
+        const path = `/assets/images/${result.filename}`;
+        imageUrlInput.value = path;
+        modal.classList.remove('hidden');
+        form.reset();
+      } else {
+        showToast(result.message || 'Erro desconhecido', 'error');
+      }
+    } catch (err) {
+      showToast('Erro ao enviar imagem', 'error');
+    }
   });
 
   function showToast(message, type = 'success') {

--- a/lib/server/security_service.rb
+++ b/lib/server/security_service.rb
@@ -1,0 +1,12 @@
+class SecurityService
+  WHITELISTED_EMAILS = [
+    "admin@example.com",
+    "moderator@example.com"
+  ].freeze
+
+  def self.is_valid?(email)
+    return false unless email && !email.strip.empty?
+
+    WHITELISTED_EMAILS.include?(email.strip.downcase)
+  end
+end

--- a/test/server/event_image_endpoint_test.rb
+++ b/test/server/event_image_endpoint_test.rb
@@ -1,0 +1,48 @@
+ENV["APP_ENV"] = "test"
+
+require "minitest/autorun"
+require "rack/test"
+require_relative "../../bin/server"
+
+class EventImageEndpointTest < Minitest::Test
+  include Rack::Test::Methods
+
+  def app
+    Sinatra::Application
+  end
+
+  def setup
+    @original_env = app.settings.environment
+    app.set :environment, :test
+  end
+
+  def teardown
+    app.set :environment, @original_env
+  end
+
+  def test_missing_token
+    post "/event_image", {}
+    assert_equal 401, last_response.status
+  end
+
+  def test_not_authorized
+    GoogleAuthService.stub :validate_token, {success: true, email: "bad@example.com"} do
+      post "/event_image", {google_token: "token"}
+    end
+    assert_equal 403, last_response.status
+  end
+
+  def test_successful_upload
+    GoogleAuthService.stub :validate_token, {success: true, email: "admin@example.com"} do
+      ImageService.stub :validate_upload, nil do
+        ImageService.stub :process_upload, "/tmp/test.webp" do
+          post "/event_image", {google_token: "token", event_image: Rack::Test::UploadedFile.new(__FILE__, "image/png")}
+        end
+      end
+    end
+    assert last_response.ok?
+    body = JSON.parse(last_response.body)
+    assert_equal "ok", body["status"]
+    assert_equal "test.webp", body["filename"]
+  end
+end


### PR DESCRIPTION
## Summary
- implement email whitelist `SecurityService`
- add `event_image` endpoint in Sinatra server
- create `event_image.html` page with optional Google sign-in
- pass new endpoint settings to Docker and CI
- document new environment variable
- test new endpoint
- switch to `BACKEND_HOST` for form actions

## Testing
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_68449958a27c832f9062c8f156151a68