### PR TITLE
Add events OCR feature

### DIFF
--- a/bin/server.rb
+++ b/bin/server.rb
@@ -12,6 +12,7 @@ require_relative "../lib/server/image_service"
 require_relative "../lib/server/github_service"
 require_relative "../lib/server/google_auth_service"
 require_relative "../lib/server/security_service"
+require_relative "../lib/server/event_ocr_service"
 
 set :bind, "0.0.0.0"
 set :port, ENV["PORT"] || 4567
@@ -140,6 +141,32 @@ post "/event_image" do
   begin
     image_path = process_event_image(params[:event_image])
     json_success("Image uploaded", {filename: File.basename(image_path, ".*")})
+  rescue => e
+    json_error(e.message)
+  end
+end
+
+post "/events_ocr" do
+  unless settings.environment == :development
+    unless params[:google_token] && !params[:google_token].strip.empty?
+      return json_error("Google authentication required", 401)
+    end
+
+    auth = GoogleAuthService.validate_token(params[:google_token])
+    unless auth[:success]
+      return json_error("Google authentication failed: #{auth[:error]}", 401)
+    end
+
+    unless SecurityService.is_valid?(auth[:email])
+      return json_error("Email not authorized", 403)
+    end
+  end
+
+  begin
+    image_path = process_event_image(params[:event_image])
+    ocr = EventOcrService.new
+    text = ocr.analyze(image_path)
+    json_success("OCR completed", {text: text})
   rescue => e
     json_error(e.message)
   end

--- a/bin/test_llm
+++ b/bin/test_llm
@@ -6,13 +6,10 @@
 require "bundler/setup"
 require "ruby_llm"
 require "pathname"
-require_relative "../lib/server/event_validation"
+require_relative "../lib/server/event_ocr_service"
 
 # Configuration
-RubyLLM.configure do |config|
-  config.gemini_api_key = ENV.fetch("GEMINI_API_KEY", nil)
-  # config.log_level = :debug  # Log level (:debug, :info, :warn)
-end
+service = EventOcrService.new
 
 # CLI argument validation
 if ARGV.length != 1
@@ -32,37 +29,10 @@ end
 begin
   puts "Analyzing image: #{image_path}"
   puts
-
-  # Create chat instance with the specified model
-  chat = RubyLLM.chat(model: "gemini-2.5-flash-preview-05-20")
-  chat.with_instructions("You are an expert in analyzing images and extracting information. Your task is to analyze the provided image and extract relevant text information in a structured format. You will be provided with an image containing text, and you should focus on extracting concise and accurate details from it. Current year is #{Time.now.year}. Return JSON with requested informations")
-
-  # Ask about text in the image
-  prompt = "Based on the photos, write concise information in European Portuguese (Portugal) about 4 events, in order. For each event, include:
-
-- Event name
-- Description
-- Location
-- Organizer
-- Start date and time (assume current year)
-  - use ISO 8601 format (YYYY-MM-DDTHH:MM:SS)
-  - If the time is not mentioned, use '00:00:00'
-  - assume event time zosne is Europe/Lisbon
-- End date and time (assume current year)
-  - use ISO 8601 format (YYYY-MM-DDTHH:MM:SS)
-  - If the time is not mentioned, use '00:00:00'
-  - assume event time zosne is Europe/Lisbon
-- Category (#{EventValidation::VALID_CATEGORIES.join(", ")})
-- Price type (#{EventValidation::VALID_PRICE_TYPES.join(", ")})
-  - If the price is not mentioned, use 'Desconhecido'
-  - If its more comples, like free till some hour, use 'Pago' and add a note in the description
-"
-
-  response = chat.ask(prompt, with: image_path)
-
+  result = service.analyze(image_path)
   puts "Analysis result:"
   puts "=" * 50
-  puts response.content
+  puts result
   puts "=" * 50
 rescue => e
   puts "Error processing image: #{e.message}"

--- a/events_listing/add_event.html
+++ b/events_listing/add_event.html
@@ -383,6 +383,7 @@ sitemap: false
 
 <!-- Google Sign-In Library -->
 <script src="https://accounts.google.com/gsi/client" async defer></script>
+<script src="/assets/js/upload_form.js"></script>
 
 <!-- AJAX form submission and toast logic -->
 <script>
@@ -390,7 +391,6 @@ sitemap: false
 
   document.addEventListener('DOMContentLoaded', () => {
     const form = document.querySelector('#add-event form');
-    const toastContainer = document.getElementById('toast-container');
     const submitBtn = document.getElementById('submit-btn');
     const imageInput = document.getElementById('event_image');
     const imagePreview = document.getElementById('image-preview');
@@ -449,10 +449,10 @@ sitemap: false
         contactEmailInput.value = payload.email;
         contactEmailInput.removeAttribute('readonly');
 
-        showToast(`Verificado com o Google como ${payload.email}`);
+        PXOForms.showToast(`Verificado com o Google como ${payload.email}`);
       } catch (error) {
         console.error('Error processing Google sign-in:', error);
-        showToast('Erro ao processar o início de sessão', 'error');
+        PXOForms.showToast('Erro ao processar o início de sessão', 'error');
       }
     }
 
@@ -465,7 +465,7 @@ sitemap: false
       if (file) {
         // Validate file size (10MB)
         if (file.size > 10 * 1024 * 1024) {
-          showToast('Tamanho do ficheiro muito grande. Tamanho máximo é 10MB.', 'error');
+          PXOForms.showToast('Tamanho do ficheiro muito grande. Tamanho máximo é 10MB.', 'error');
           imageInput.value = '';
           return;
         }
@@ -473,7 +473,7 @@ sitemap: false
         // Validate file type
         const allowedTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp', 'image/bmp', 'image/tiff'];
         if (!allowedTypes.includes(file.type)) {
-          showToast('Tipo de ficheiro inválido. Por favor, carregue um ficheiro de imagem.', 'error');
+          PXOForms.showToast('Tipo de ficheiro inválido. Por favor, carregue um ficheiro de imagem.', 'error');
           imageInput.value = '';
           return;
         }
@@ -496,91 +496,23 @@ sitemap: false
       imagePreview.classList.add('hidden');
     });
 
-    function showToast(message, type = 'success') {
-      const bg = type === 'success' ? 'bg-green-500' : 'bg-red-500';
-      const toast = document.createElement('div');
-      toast.setAttribute('role', 'alert');
-      toast.className = `${bg} text-white px-4 py-2 rounded shadow transition-opacity duration-500`;
-      toast.textContent = message;
-      toastContainer.appendChild(toast);
-      // Auto-hide after 3s
-      setTimeout(() => {
-        toast.classList.add('opacity-0');
-        toast.addEventListener('transitionend', () => toast.remove());
-      }, 3000);
-    }
-
-    form.addEventListener('submit', async (e) => {
+    form.addEventListener('submit', (e) => {
       e.preventDefault();
 
-      // Check if user is authenticated with Google
       if (!googleCredential || !googleTokenInput.value) {
-        showToast('É obrigatório iniciar sessão com o Google antes de submeter um evento.', 'error');
+        PXOForms.showToast('É obrigatório iniciar sessão com o Google antes de submeter um evento.', 'error');
         return;
       }
 
-      // disable and show spinner
-      submitBtn.disabled = true;
-      submitBtn.classList.add('is-loading');
-      const data = new FormData(form);
-
-      // Create AbortController for timeout (90 seconds to handle Render wake-up)
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), 90000); // 90 seconds
-
-      try {
-        const response = await fetch(form.action, {
-          method: 'POST',
-          body: data,
-          signal: controller.signal
-        });
-        clearTimeout(timeoutId);
-
-        if (!response.ok) {
-          let errorMsg = `HTTP ${response.status}`;
-          try {
-            const result = await response.json();
-            errorMsg = result.message || errorMsg;
-          } catch (parseError) {
-            errorMsg += ` - ${response.statusText}`;
-          }
-          showToast(`Erro do servidor: ${errorMsg}`, 'error');
-          return;
-        }
-
-        const result = await response.json();
-        if (result.status === 'ok') {
-          showToast(`Evento "${result.event_name}" adicionado com sucesso!`);
+      PXOForms.submitUploadForm({
+        form,
+        submitBtn,
+        onSuccess: (result) => {
+          PXOForms.showToast(`Evento \"${result.event_name}\" adicionado com sucesso!`);
           form.reset();
-          imagePreview.classList.add('hidden'); // Hide image preview after reset
-        } else {
-          const errorMsg = result.message || 'Ocorreu um erro desconhecido';
-          showToast(`Erro: ${errorMsg}`, 'error');
+          imagePreview.classList.add('hidden');
         }
-      } catch (error) {
-        console.error('Submission error:', error);
-        let errorMsg = 'Erro de rede';
-
-        // Add file info if image is attached
-        const imageFile = imageInput.files[0];
-        const fileInfo = imageFile ? ` (Com imagem: ${imageFile.name}, ${(imageFile.size/1024/1024).toFixed(1)}MB)` : '';
-
-        if (error.name === 'TypeError' && error.message.includes('fetch')) {
-          errorMsg += ' - Não foi possível ligar ao servidor';
-        } else if (error.name === 'SyntaxError') {
-          errorMsg += ' - Resposta inválida do servidor';
-        } else if (error.name === 'AbortError') {
-          errorMsg += ' - O servidor demorou muito tempo a responder (timeout após 90 segundos)';
-        } else if (error.message) {
-          errorMsg += ` - ${error.name}: ${error.message}`;
-        }
-
-        showToast(`${errorMsg}${fileInfo}. Verifique a ligação e tente novamente.`, 'error');
-      } finally {
-        // re-enable and hide spinner
-        submitBtn.disabled = false;
-        submitBtn.classList.remove('is-loading');
-      }
+      });
     });
   });
 </script>

--- a/events_listing/assets/js/upload_form.js
+++ b/events_listing/assets/js/upload_form.js
@@ -1,0 +1,47 @@
+(function() {
+  function showToast(message, type = 'success') {
+    const container = document.getElementById('toast-container');
+    if (!container) return;
+    const bg = type === 'success' ? 'bg-green-500' : 'bg-red-500';
+    const toast = document.createElement('div');
+    toast.className = `${bg} text-white px-4 py-2 rounded shadow transition-opacity duration-500`;
+    toast.textContent = message;
+    container.appendChild(toast);
+    setTimeout(() => {
+      toast.classList.add('opacity-0');
+      toast.addEventListener('transitionend', () => toast.remove());
+    }, 3000);
+  }
+
+  function submitUploadForm({ form, submitBtn, onSuccess }) {
+    const data = new FormData(form);
+    submitBtn.disabled = true;
+    submitBtn.classList.add('is-loading');
+    fetch(form.action, { method: 'POST', body: data })
+      .then(async (response) => {
+        if (!response.ok) {
+          let msg = `Erro ${response.status}`;
+          try {
+            const r = await response.json();
+            msg = r.message || msg;
+          } catch (_) {}
+          throw new Error(msg);
+        }
+        const result = await response.json();
+        if (result.status === 'ok') {
+          onSuccess(result);
+        } else {
+          throw new Error(result.message || 'Erro desconhecido');
+        }
+      })
+      .catch((err) => {
+        showToast(err.message, 'error');
+      })
+      .finally(() => {
+        submitBtn.disabled = false;
+        submitBtn.classList.remove('is-loading');
+      });
+  }
+
+  window.PXOForms = { showToast, submitUploadForm };
+})();

--- a/events_listing/events_ocr.html
+++ b/events_listing/events_ocr.html
@@ -1,12 +1,12 @@
 ---
 layout: default
-title: "Carregar Imagem"
-permalink: /event_image/
+title: "OCR de Eventos"
+permalink: /events_ocr/
 sitemap: false
 ---
 
-<section id="image-upload" class="max-w-xl mx-auto py-8">
-  <h1 class="page-title">Carregar Imagem do Evento</h1>
+<section id="ocr-upload" class="max-w-xl mx-auto py-8">
+  <h1 class="page-title">Reconhecimento de Texto de Evento</h1>
   {% unless jekyll.environment == 'development' %}
   <div id="google-area" class="mb-6 p-6 bg-white rounded-lg shadow-lg border-b-4 border-buttons">
     <div id="google-signin"></div>
@@ -15,7 +15,7 @@ sitemap: false
     </div>
   </div>
   {% endunless %}
-  <form action="{{ site.env.BACKEND_HOST }}/event_image" method="POST" enctype="multipart/form-data" class="space-y-6">
+  <form action="{{ site.env.BACKEND_HOST }}/events_ocr" method="POST" enctype="multipart/form-data" class="space-y-6">
     <input type="hidden" name="google_token" id="google_token" value="">
     <div>
       <label for="event_image" class="form-label">Imagem <span class="text-red-500">*</span></label>
@@ -36,14 +36,9 @@ sitemap: false
 
   <div id="result-modal" class="hidden fixed inset-0 z-50 flex items-center justify-center">
     <div class="absolute inset-0 bg-black/50"></div>
-    <div class="relative bg-white rounded-lg shadow-lg p-6 space-y-4 w-11/12 max-w-md">
-      <p class="font-semibold">Imagem carregada</p>
-      <div class="relative">
-        <input type="text" id="image-url" readonly class="form-input cursor-pointer pr-10" title="Clique para copiar" />
-        <svg id="copy-icon" class="absolute right-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-500 cursor-pointer hover:text-gray-700" fill="none" stroke="currentColor" viewBox="0 0 24 24" title="Clique para copiar">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
-        </svg>
-      </div>
+    <div class="relative bg-white rounded-lg shadow-lg p-6 space-y-4 w-11/12 max-w-2xl">
+      <p class="font-semibold">Resultado do OCR</p>
+      <textarea id="ocr-text" class="form-input w-full h-64" readonly></textarea>
       <button id="close-modal" class="navigation-button w-full">Fechar</button>
     </div>
   </div>
@@ -79,31 +74,13 @@ sitemap: false
   document.addEventListener('DOMContentLoaded', initGoogle);
 {% endunless %}
 
-  const form = document.querySelector('#image-upload form');
+  const form = document.querySelector('#ocr-upload form');
   const modal = document.getElementById('result-modal');
-  const imageUrlInput = document.getElementById('image-url');
+  const ocrText = document.getElementById('ocr-text');
   const closeModalBtn = document.getElementById('close-modal');
-  const copyIcon = document.getElementById('copy-icon');
   const submitBtn = document.getElementById('submit-btn');
 
   closeModalBtn.addEventListener('click', () => modal.classList.add('hidden'));
-
-  // Function to copy the URL to clipboard
-  async function copyToClipboard() {
-    try {
-      await navigator.clipboard.writeText(imageUrlInput.value);
-      PXOForms.showToast('URL copiado para a área de transferência!', 'success');
-    } catch (err) {
-      // Fallback for older browsers
-      imageUrlInput.select();
-      document.execCommand('copy');
-      PXOForms.showToast('URL copiado para a área de transferência!', 'success');
-    }
-  }
-
-  // Add copy functionality to both the input and the icon
-  imageUrlInput.addEventListener('click', copyToClipboard);
-  copyIcon.addEventListener('click', copyToClipboard);
 
   form.addEventListener('submit', (e) => {
     e.preventDefault();
@@ -117,7 +94,7 @@ sitemap: false
       form,
       submitBtn,
       onSuccess: (result) => {
-        imageUrlInput.value = result.filename;
+        ocrText.value = result.text;
         modal.classList.remove('hidden');
         form.reset();
       }

--- a/lib/server/event_ocr_service.rb
+++ b/lib/server/event_ocr_service.rb
@@ -1,0 +1,39 @@
+class EventOcrService
+  MODEL = "gemini-2.5-flash-preview-05-20"
+
+  def initialize(api_key: ENV.fetch("GEMINI_API_KEY", nil))
+    @api_key = api_key
+    RubyLLM.configure do |config|
+      config.gemini_api_key = @api_key
+    end
+  end
+
+  def analyze(image_path)
+    chat = RubyLLM.chat(model: MODEL)
+    chat.with_instructions <<~INSTR
+      You are an expert in analyzing images and extracting information. Your task is to analyze the provided image and extract relevant text information in a structured format. You will be provided with an image containing text, and you should focus on extracting concise and accurate details from it. Current year is #{Time.now.year}. Return JSON with requested informations
+    INSTR
+
+    prompt = <<~PROMPT
+      Based on the photos, write concise information in European Portuguese (Portugal) about 4 events, in order. For each event, include:
+
+      - Event name
+      - Description
+      - Location
+      - Organizer
+      - Start date and time (assume current year)
+        - use ISO 8601 format (YYYY-MM-DDTHH:MM:SS)
+        - If the time is not mentioned, use '00:00:00'
+        - assume event time zosne is Europe/Lisbon
+      - End date and time (assume current year)
+        - use ISO 8601 format (YYYY-MM-DDTHH:MM:SS)
+        - If the time is not mentioned, use '00:00:00'
+        - assume event time zosne is Europe/Lisbon
+      - Category (#{EventValidation::VALID_CATEGORIES.join(', ')})
+      - Price type (#{EventValidation::VALID_PRICE_TYPES.join(', ')})
+        - If the price is not mentioned, use 'Desconhecido'
+        - If its more comples, like free till some hour, use 'Pago' and add a note in the description
+    PROMPT
+    chat.ask(prompt, with: image_path).content
+  end
+end

--- a/test/server/events_ocr_endpoint_test.rb
+++ b/test/server/events_ocr_endpoint_test.rb
@@ -1,0 +1,52 @@
+ENV["APP_ENV"] = "test"
+
+require "minitest/autorun"
+require "rack/test"
+require_relative "../../bin/server"
+
+class EventsOcrEndpointTest < Minitest::Test
+  include Rack::Test::Methods
+
+  def app
+    Sinatra::Application
+  end
+
+  def setup
+    @orig_env = app.settings.environment
+    app.set :environment, :test
+  end
+
+  def teardown
+    app.set :environment, @orig_env
+  end
+
+  def test_missing_token
+    post "/events_ocr", {}
+    assert_equal 401, last_response.status
+  end
+
+  def test_not_authorized
+    GoogleAuthService.stub :validate_token, {success: true, email: "bad@example.com"} do
+      post "/events_ocr", {google_token: "token"}
+    end
+    assert_equal 403, last_response.status
+  end
+
+  def test_successful_ocr
+    mock = Object.new
+    def mock.analyze(_path); "csv"; end
+    EventOcrService.stub :new, mock do
+      GoogleAuthService.stub :validate_token, {success: true, email: SecurityService::WHITELISTED_EMAILS.first} do
+        ImageService.stub :validate_upload, nil do
+          ImageService.stub :process_upload, "/tmp/test.webp" do
+            post "/events_ocr", {google_token: "token", event_image: Rack::Test::UploadedFile.new(__FILE__, "image/png")}
+          end
+        end
+      end
+    end
+    assert last_response.ok?
+    body = JSON.parse(last_response.body)
+    assert_equal "ok", body["status"]
+    assert_equal "csv", body["text"]
+  end
+end


### PR DESCRIPTION
## Summary
- extract Gemini logic into `EventOcrService`
- expose `/events_ocr` endpoint in Sinatra app
- make CLI use the new service
- add Jekyll page for OCR upload
- test OCR endpoint
- keep OCR prompt in English
- refactor image forms to show loading state with shared JS helper
- reuse upload helper on `add_event` page

## Testing
- `rake test`


------
https://chatgpt.com/codex/tasks/task_e_68468a17dd64832fae4a49f495bba157