### PR TITLE
Fix add_event form submission

### DIFF
--- a/events_listing/add_event.html
+++ b/events_listing/add_event.html
@@ -497,11 +497,22 @@ sitemap: false
     });
 
     form.addEventListener('submit', (e) => {
+      e.preventDefault();
+{% unless jekyll.environment == 'development' %}
+      if (!googleCredential || !googleTokenInput.value) {
         PXOForms.showToast('É obrigatório iniciar sessão com o Google antes de submeter um evento.', 'error');
+        return;
+      }
+{% endunless %}
       PXOForms.submitUploadForm({
         form,
         submitBtn,
         onSuccess: (result) => {
-          PXOForms.showToast(`Evento \"${result.event_name}\" adicionado com sucesso!`);
+          PXOForms.showToast(`Evento "${result.event_name}" adicionado com sucesso!`);
+          form.reset();
           imagePreview.classList.add('hidden');
+        }
       });
+    });
+  });
+</script>


### PR DESCRIPTION
## Summary
- fix missing JS for add_event form to display toast and prevent normal submission

## Testing
- `bundle exec rubocop -a`
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_6846cd6ef280832fa08f3a8335987f26