### PR TITLE
Add Selenium docker and remote driver support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,6 @@ GH_TOKEN=your-github-token
 BACKEND_HOST=http://localhost:4001
 
 GEMINI_API_KEY=your-gemini-api-key
+
+# Selenium remote driver URL
+SELENIUM_REMOTE_URL=http://localhost:4444/wd/hub

--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,5 @@ GEMINI_API_KEY=your-gemini-api-key
 
 # Selenium remote driver URL
 SELENIUM_REMOTE_URL=http://localhost:4444/wd/hub
+# Hostname that Selenium uses to reach the test container
+APP_HOST=host.docker.internal

--- a/.github/workflows/docker_checks.yml
+++ b/.github/workflows/docker_checks.yml
@@ -68,6 +68,9 @@ jobs:
         run: |
           docker compose run --rm app rubocop
 
+      - name: Start Selenium
+        run: docker compose up -d selenium
+
       - name: Run Tests
         run: |
           docker compose run --rm app rake test

--- a/.github/workflows/docker_checks.yml
+++ b/.github/workflows/docker_checks.yml
@@ -69,6 +69,7 @@ jobs:
           docker compose run --rm app rubocop
 
       - name: Start Selenium
+        # "docker compose run" won't start dependency services, so start Selenium manually
         run: docker compose up -d selenium
 
       - name: Run Tests

--- a/README.md
+++ b/README.md
@@ -37,3 +37,5 @@ Run the tests with the remote driver:
 ```bash
 SELENIUM_REMOTE_URL=http://localhost:4444/wd/hub rake test
 ```
+
+You can also set `SELENIUM_REMOTE_URL` in your `.env` file for Docker Compose.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ docker compose up -d selenium
 Run the tests with the remote driver:
 
 ```bash
+APP_HOST=host.docker.internal \
 SELENIUM_REMOTE_URL=http://localhost:4444/wd/hub rake test
 ```
 
-You can also set `SELENIUM_REMOTE_URL` in your `.env` file for Docker Compose.
+`APP_HOST` should point to the hostname that Selenium can use to reach the test
+server. On Docker Desktop, `host.docker.internal` works by default. You can also
+set `SELENIUM_REMOTE_URL` and `APP_HOST` in your `.env` file for Docker Compose.

--- a/README.md
+++ b/README.md
@@ -23,3 +23,17 @@ Use the CLI for options:
 ```bash
 ./bin/cli -u "https://example.com/events.csv" -o events.ics
 ```
+
+## Browser Tests
+
+The browser test suite uses Capybara with Selenium. Start the Selenium container:
+
+```bash
+docker compose up -d selenium
+```
+
+Run the tests with the remote driver:
+
+```bash
+SELENIUM_REMOTE_URL=http://localhost:4444/wd/hub rake test
+```

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -3,6 +3,7 @@ services:
     image: ghcr.io/zewelor/ps_events:dev
     environment:
       SELENIUM_REMOTE_URL: "http://selenium:4444/wd/hub"
+      APP_HOST: app
     volumes:
       - .:/app
     depends_on:

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,5 +1,11 @@
 services:
   app:
     image: ghcr.io/zewelor/ps_events:dev
+    environment:
+      SELENIUM_REMOTE_URL: "http://selenium:4444/wd/hub"
     volumes:
       - .:/app
+    depends_on:
+      - selenium
+  selenium:
+    image: selenium/standalone-chrome:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
     <<: *x-app
     env_file:
       - .env
+    environment:
+      SELENIUM_REMOTE_URL: "http://selenium:4444/wd/hub"
     command:
       - sh
       - -c

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - .env
     environment:
       SELENIUM_REMOTE_URL: "http://selenium:4444/wd/hub"
+      APP_HOST: app
     command:
       - sh
       - -c

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,10 @@ services:
       - --
       - ruby
       - bin/server.rb
+  selenium:
+    image: selenium/standalone-chrome:latest
+    ports:
+      - "127.0.0.1:4444:4444"
 
 
 volumes:

--- a/test/browser/add_event_browser_test.rb
+++ b/test/browser/add_event_browser_test.rb
@@ -17,7 +17,7 @@ Capybara.register_driver :headless_chrome do |app|
     Capybara::Selenium::Driver.new(app,
       browser: :remote,
       url: ENV.fetch("SELENIUM_REMOTE_URL", "http://localhost:4444/wd/hub"),
-      capabilities: options)
+      options: options)
   else
     Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
   end
@@ -25,6 +25,11 @@ end
 
 Capybara.default_driver = :headless_chrome
 Capybara.server = :puma, {Silent: true}
+
+if ENV["SELENIUM_REMOTE_URL"]
+  Capybara.server_host = "0.0.0.0"
+  Capybara.app_host = "http://#{ENV.fetch("APP_HOST", "host.docker.internal")}:#{Capybara.server_port}"
+end
 
 class AddEventBrowserTest < Minitest::Test
   include Capybara::DSL

--- a/test/browser/add_event_browser_test.rb
+++ b/test/browser/add_event_browser_test.rb
@@ -12,7 +12,15 @@ Capybara.register_driver :headless_chrome do |app|
   options.add_argument("--disable-gpu")
   options.add_argument("--no-sandbox")
   options.add_argument("--disable-dev-shm-usage")
-  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+
+  if ENV["SELENIUM_REMOTE_URL"]
+    Capybara::Selenium::Driver.new(app,
+      browser: :remote,
+      url: ENV.fetch("SELENIUM_REMOTE_URL", "http://localhost:4444/wd/hub"),
+      capabilities: options)
+  else
+    Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+  end
 end
 
 Capybara.default_driver = :headless_chrome


### PR DESCRIPTION
## Summary
- add `selenium` service for Docker Compose
- allow Capybara to connect to remote Selenium via `SELENIUM_REMOTE_URL`
- document how to run browser tests with Selenium

## Testing
- `rubocop -a`
- `rake test` *(fails: connection refused for Selenium remote URL)*
- `SELENIUM_REMOTE_URL=http://localhost:4444/wd/hub rake test` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6846e1ffe900832fb06a5af444848d36