### PR TITLE
Enable event OCR sheet upload

### DIFF
--- a/bin/server.rb
+++ b/bin/server.rb
@@ -80,6 +80,49 @@ helpers do
       raise StandardError, "Image processing failed: #{e.message}"
     end
   end
+
+  def add_event_to_sheet(validated_params, submitter_email, image_path = "")
+    start_date_str = Date.parse(validated_params[:start_date]).strftime("%d/%m/%Y")
+    start_time_str = validated_params[:start_time]&.strip || ""
+    end_date_str = Date.parse(validated_params[:end_date]).strftime("%d/%m/%Y")
+    end_time_str = validated_params[:end_time]&.strip || ""
+
+    submitted_at = Time.now.strftime("%d/%m/%Y %H:%M")
+
+    image_filename = image_path.empty? ? "" : File.basename(image_path, ".*")
+
+    contact_email = validated_params[:contact_email]&.strip&.downcase
+
+    event_data = [
+      submitted_at,
+      submitter_email,
+      validated_params[:name].strip,
+      start_date_str,
+      start_time_str,
+      end_date_str,
+      end_time_str,
+      validated_params[:location].strip,
+      validated_params[:description].strip,
+      validated_params[:category].strip,
+      validated_params[:organizer].strip,
+      contact_email,
+      validated_params[:contact_tel]&.strip || "",
+      validated_params[:price_type]&.strip || "",
+      image_filename,
+      validated_params[:event_link1]&.strip || "",
+      validated_params[:event_link2]&.strip || "",
+      validated_params[:event_link3]&.strip || "",
+      validated_params[:event_link4]&.strip || ""
+    ]
+
+    masked_data = event_data.dup
+    masked_data[1] = "#{masked_data[1].split("@").first}@***" if masked_data[1].include?("@")
+    masked_data[11] = "#{masked_data[11].split("@").first}@***" if masked_data[11]&.include?("@")
+    puts "✅ Adding event: #{masked_data[2]} by #{masked_data[10]} on #{masked_data[3]} #{masked_data[4]} (submitted by #{masked_data[1]}, contact: #{masked_data[11]})"
+
+    settings.google_sheets.append_row(settings.spreadsheet_id, settings.events_range, event_data)
+    event_data
+  end
 end
 
 # Initialize Google Sheets service
@@ -147,7 +190,9 @@ post "/event_image" do
 end
 
 post "/events_ocr" do
-  unless settings.environment == :development
+  if settings.environment == :development
+    auth = {email: "dev@example.com"}
+  else
     unless params[:google_token] && !params[:google_token].strip.empty?
       return json_error("Google authentication required", 401)
     end
@@ -163,10 +208,35 @@ post "/events_ocr" do
   end
 
   begin
-    image_path = ImageService.process_upload(params[:event_image])
+    image_path = process_event_image(params[:event_image])
     ocr = EventOcrService.new
     text = ocr.analyze(image_path)
-    json_success("OCR completed", {text: text})
+
+    events = JSON.parse(text)
+    validator = EventValidation.new
+    added = []
+
+    events.each do |event|
+      event["start_date"] = begin
+        Date.strptime(event["start_date"], "%d/%m/%Y").strftime("%Y-%m-%d")
+      rescue
+        next
+      end
+      event["end_date"] = begin
+        Date.strptime(event["end_date"], "%d/%m/%Y").strftime("%Y-%m-%d")
+      rescue
+        next
+      end
+      result = validator.call(event)
+      next unless result.success?
+
+      add_event_to_sheet(result.to_h, auth[:email], image_path)
+      added << result.to_h[:name]
+    end
+
+    json_success("OCR completed", {text: text, added: added})
+  rescue JSON::ParserError => e
+    json_error("Invalid OCR response: #{e.message}")
   rescue => e
     json_error(e.message)
   end
@@ -211,73 +281,14 @@ post "/add_event" do
     validated_params = result.to_h
     puts "✅ Validation successful for event: #{validated_params[:name]}"
 
-    # Format individual start and end date and time components
-    start_date_str = Date.parse(validated_params[:start_date]).strftime("%d/%m/%Y")
-    start_time_str = validated_params[:start_time]&.strip || ""
-    end_date_str = Date.parse(validated_params[:end_date]).strftime("%d/%m/%Y")
-    end_time_str = validated_params[:end_time]&.strip || ""
-
-    # Format submitted at timestamp
-    submitted_at = Time.now.strftime("%d/%m/%Y %H:%M")
-
-    # Prepare event data for spreadsheet
-    # Extract only filename from image_path if present (without extension)
-    image_filename = image_path.empty? ? "" : File.basename(image_path, ".*")
-
-    # Use Google authenticated email as submitter (who actually submitted)
-    submitter_email = google_user_email
-
-    # Use the provided contact email (which may be different from submitter)
-    contact_email = validated_params[:contact_email]&.strip&.downcase
-
-    # Log if submitter and contact are different (for moderator cases)
-    if contact_email != google_user_email.downcase
-      puts "ℹ️ Event submitted by #{google_user_email} for contact #{contact_email}"
+    if validated_params[:contact_email] && validated_params[:contact_email].downcase != google_user_email.downcase
+      puts "ℹ️ Event submitted by #{google_user_email} for contact #{validated_params[:contact_email]}"
     end
 
-    event_data = [
-      submitted_at,
-      submitter_email,
-      validated_params[:name].strip,
-      start_date_str,
-      start_time_str,
-      end_date_str,
-      end_time_str,
-      validated_params[:location].strip,
-      validated_params[:description].strip,
-      validated_params[:category].strip,
-      validated_params[:organizer].strip,
-      contact_email, # Use the provided contact email
-      validated_params[:contact_tel]&.strip || "",
-      validated_params[:price_type]&.strip || "",
-      image_filename, # Store only the filename
-      validated_params[:event_link1]&.strip || "",
-      validated_params[:event_link2]&.strip || "",
-      validated_params[:event_link3]&.strip || "",
-      validated_params[:event_link4]&.strip || ""
-    ]
-
-    # Log the event data (mask sensitive info)
-    masked_data = event_data.dup
-    masked_data[1] = "#{masked_data[1].split("@").first}@***" if masked_data[1].include?("@") # submitter
-    masked_data[11] = "#{masked_data[11].split("@").first}@***" if masked_data[11]&.include?("@") # contact
-    puts "✅ Adding event: #{masked_data[2]} by #{masked_data[10]} on #{masked_data[3]} #{masked_data[4]} (submitted by #{masked_data[1]}, contact: #{masked_data[11]})"
-
     begin
-      # Add to Google Sheets
-      settings.google_sheets.append_row(
-        settings.spreadsheet_id,
-        settings.events_range,
-        event_data
-      )
-
+      add_event_to_sheet(validated_params, google_user_email, image_path)
       puts "✅ Event successfully added to spreadsheet"
-
-      # Respond with JSON status
-      json_success("Event added successfully", {
-        event_name: validated_params[:name],
-        event_date: start_date_str
-      })
+      json_success("Event added successfully", {event_name: validated_params[:name], event_date: Date.parse(validated_params[:start_date]).strftime("%d/%m/%Y")})
     rescue => e
       puts "❌ Error adding event: #{e.message}"
       puts "   Backtrace: #{e.backtrace.first(3).join(" | ")}"

--- a/test/server/events_ocr_endpoint_test.rb
+++ b/test/server/events_ocr_endpoint_test.rb
@@ -7,17 +7,32 @@ require_relative "../../bin/server"
 class EventsOcrEndpointTest < Minitest::Test
   include Rack::Test::Methods
 
+  class DummySheets
+    attr_reader :rows
+
+    def initialize
+      @rows = []
+    end
+
+    def append_row(_spreadsheet_id, _range, data)
+      @rows << data
+    end
+  end
+
   def app
     Sinatra::Application
   end
 
   def setup
     @orig_env = app.settings.environment
+    @orig_sheets = app.settings.google_sheets
     app.set :environment, :test
+    app.settings.google_sheets = DummySheets.new
   end
 
   def teardown
     app.set :environment, @orig_env
+    app.settings.google_sheets = @orig_sheets
   end
 
   def test_missing_token
@@ -35,7 +50,7 @@ class EventsOcrEndpointTest < Minitest::Test
   def test_successful_ocr
     mock = Object.new
     def mock.analyze(_path)
-      "csv"
+      '[{"name":"Test","description":"Uma descricao valida","location":"Porto","organizer":"Org","start_date":"01/12/2025","start_time":"","end_date":"02/12/2025","end_time":"","category":"Música","price_type":"Gratuito"}]'
     end
 
     EventOcrService.stub :new, mock do
@@ -50,6 +65,6 @@ class EventsOcrEndpointTest < Minitest::Test
     assert last_response.ok?
     body = JSON.parse(last_response.body)
     assert_equal "ok", body["status"]
-    assert_equal "csv", body["text"]
+    assert_equal 1, app.settings.google_sheets.rows.length
   end
 end


### PR DESCRIPTION
## Summary
- add helper for appending events to Google Sheets
- reuse helper in `/add_event`
- extend `/events_ocr` endpoint to parse OCR output and add events automatically
- adjust tests to verify sheet append behaviour

## Testing
- `bundle exec rubocop`
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_6847ecf4d994832f9e5c1b2fe38c5d5e