### PR TITLE
Introduce json schema validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gem "zeitwerk"
 gem "sinatra"
 gem "dry-validation", "~> 1.11"
+gem "json-schema", "~> 5.1"
 
 group :development, :test do
   gem "debug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,6 +153,9 @@ GEM
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     json (2.12.0)
+    json-schema (5.1.1)
+      addressable (~> 2.8)
+      bigdecimal (~> 3.1)
     jwt (2.10.1)
       base64
     kramdown (2.5.1)
@@ -336,6 +339,7 @@ DEPENDENCIES
   jekyll-seo-tag!
   jekyll-sitemap (~> 1.4)
   jekyll-tailwindcss
+  json-schema (~> 5.1)
   lefthook
   mini_magick (~> 5.2)
   minitest (~> 5.25)

--- a/bin/server.rb
+++ b/bin/server.rb
@@ -202,6 +202,7 @@ post "/add_event" do
   # Remove the file upload from params for validation
   validation_params = params.dup
   validation_params.delete(:event_image)
+  validation_params.delete(:google_token)
 
   # Validate the event data using dry-validation directly
   validator = EventValidation.new

--- a/lib/server/event_schema.json
+++ b/lib/server/event_schema.json
@@ -1,0 +1,35 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "name",
+    "start_date",
+    "end_date",
+    "location",
+    "description",
+    "category",
+    "organizer"
+  ],
+  "properties": {
+    "name": { "type": "string", "minLength": 3, "maxLength": 200 },
+    "start_date": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$", "format": "date" },
+    "start_time": { "type": "string", "pattern": "^(|\\d{2}:\\d{2})$" },
+    "end_date": { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$", "format": "date" },
+    "end_time": { "type": "string", "pattern": "^(|\\d{2}:\\d{2})$" },
+    "location": { "type": "string", "minLength": 3, "maxLength": 100 },
+    "description": { "type": "string", "minLength": 10, "maxLength": 1000 },
+    "category": { "type": "string", "enum": [
+      "Música", "Comida", "Arte", "Natureza", "Saúde & Bem-Estar",
+      "Desporto", "Aprendizagem & Workshops", "Comunidade & Cultura"
+    ] },
+    "organizer": { "type": "string", "minLength": 2, "maxLength": 100 },
+    "contact_email": { "type": "string", "pattern": "^(|[\\w+\\-.]+@[a-z\\d\\-]+(\\.[a-z\\d\\-]+)*\\.[a-z]+)$" },
+    "contact_tel": { "type": "string", "pattern": "^(|(?=(?:.*\\d){7,})[\\d\\s\\-\\(\\)\\+]+)$" },
+    "price_type": { "type": "string", "pattern": "^(|Gratuito|Pago|Desconhecido)$" },
+    "event_link1": { "type": "string", "pattern": "^(|https?://.+)$" },
+    "event_link2": { "type": "string", "pattern": "^(|https?://.+)$" },
+    "event_link3": { "type": "string", "pattern": "^(|https?://.+)$" },
+    "event_link4": { "type": "string", "pattern": "^(|https?://.+)$" },
+    "event_image": { "type": "object" }
+  }
+}

--- a/lib/server/event_validation.rb
+++ b/lib/server/event_validation.rb
@@ -1,183 +1,97 @@
-require "dry/validation"
+require "json-schema"
+require "date"
+require "time"
 
-# Event validation contract using dry-validation
-class EventValidation < Dry::Validation::Contract
+class EventValidation
+  SCHEMA_PATH = File.expand_path("event_schema.json", __dir__)
+  SCHEMA = JSON.parse(File.read(SCHEMA_PATH))
+
   VALID_CATEGORIES = [
     "Música", "Comida", "Arte", "Natureza", "Saúde & Bem-Estar",
     "Desporto", "Aprendizagem & Workshops", "Comunidade & Cultura"
   ].freeze
 
-  VALID_PRICE_TYPES = ["Gratuito", "Pago", "Desconhecido"].freeze
+  Result = Struct.new(:data, :errors) do
+    def success?
+      errors.empty?
+    end
 
-  params do
-    required(:name).filled(:string)
-    required(:start_date).filled(:string)
-    optional(:start_time).maybe(:string)
-    required(:end_date).filled(:string)
-    optional(:end_time).maybe(:string)
-    required(:location).filled(:string)
-    required(:description).filled(:string)
-    required(:category).filled(:string)
-    required(:organizer).filled(:string)
-    optional(:contact_email).maybe(:string)
-    optional(:contact_tel).maybe(:string)
-    optional(:price_type).maybe(:string)
-    optional(:event_link1).maybe(:string)
-    optional(:event_link2).maybe(:string)
-    optional(:event_link3).maybe(:string)
-    optional(:event_link4).maybe(:string)
-    optional(:event_image).maybe(:hash)
-  end
+    def failure?
+      !success?
+    end
 
-  rule(:contact_email) do
-    if key? && value && !value.empty?
-      unless /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i.match?(value)
-        key.failure("must be a valid email address")
-      end
+    def to_h
+      data
     end
   end
 
-  rule(:start_date) do
-    if /\A\d{4}-\d{2}-\d{2}\z/.match?(value)
+  def call(params)
+    errors = schema_errors(params)
+    validate_relations(params, errors)
+    Result.new(params, errors)
+  end
+
+  private
+
+  def schema_errors(params)
+    errs = JSON::Validator.fully_validate(SCHEMA, params, errors_as_objects: true)
+    errs.each_with_object({}) do |err, h|
+      field = err[:fragment].sub("#/", "").to_sym
+      (h[field] ||= []) << err[:message]
+    end
+  end
+
+  def validate_relations(params, errors)
+    begin
+      Date.strptime(params[:start_date], "%Y-%m-%d")
+    rescue ArgumentError
+      (errors[:start_date] ||= []) << "must be a valid date (e.g., month between 01-12, day between 01-31)"
+    end
+
+    begin
+      Date.strptime(params[:end_date], "%Y-%m-%d")
+    rescue ArgumentError
+      (errors[:end_date] ||= []) << "must be a valid date (e.g., month between 01-12, day between 01-31)"
+    end
+
+    if params[:start_time] && !params[:start_time].to_s.empty?
       begin
-        Date.strptime(value, "%Y-%m-%d")
+        Time.parse(params[:start_time])
       rescue ArgumentError
-        key.failure("must be a valid date (e.g., month between 01-12, day between 01-31)")
+        (errors[:start_time] ||= []) << "must be a valid time format (HH:MM)"
       end
-    else
-      key.failure("must be a valid date format (YYYY-MM-DD)")
     end
-  end
 
-  rule(:start_time) do
-    if key? && value && !value.empty?
+    if params[:end_time] && !params[:end_time].to_s.empty?
       begin
-        Time.parse(value)
+        Time.parse(params[:end_time])
       rescue ArgumentError
-        key.failure("must be a valid time format (HH:MM)")
+        (errors[:end_time] ||= []) << "must be a valid time format (HH:MM)"
       end
     end
-  end
 
-  rule(:end_date) do
-    if /\A\d{4}-\d{2}-\d{2}\z/.match?(value)
+    unless errors[:end_date] || errors[:start_date]
       begin
-        end_date = Date.strptime(value, "%Y-%m-%d")
-        start_val = values[:start_date]
-        start_date = nil
-        if start_val && /\A\d{4}-\d{2}-\d{2}\z/.match?(start_val) # Ensure start_val is also in correct format before parsing
-          begin
-            start_date = Date.strptime(start_val, "%Y-%m-%d")
-          rescue ArgumentError
-            # This should ideally not happen if start_date rule passed
-          end
-        end
-
-        if start_date && end_date < start_date
-          key.failure("must be on or after start date")
-        end
-      rescue ArgumentError
-        key.failure("must be a valid date (e.g., month between 01-12, day between 01-31)")
-      end
-    else
-      key.failure("must be a valid date format (YYYY-MM-DD)")
-    end
-  end
-
-  rule(:end_time) do
-    if key? && value && !value.empty?
-      begin
-        Time.parse(value)
-      rescue ArgumentError
-        key.failure("must be a valid time format (HH:MM)")
-      end
-    end
-  end
-
-  rule(:start_date, :start_time, :end_date, :end_time) do
-    if values[:start_date] && values[:end_date]
-      begin
-        start_date_obj = Date.strptime(values[:start_date], "%Y-%m-%d")
-        end_date_obj = Date.strptime(values[:end_date], "%Y-%m-%d")
-
-        if start_date_obj == end_date_obj && values[:start_time] && values[:end_time] &&
-            !values[:start_time].empty? && !values[:end_time].empty?
-          start_time = Time.parse(values[:start_time])
-          end_time = Time.parse(values[:end_time])
-
-          if end_time <= start_time
-            key(:end_time).failure("must be after start time when on the same date")
-          end
+        end_date = Date.strptime(params[:end_date], "%Y-%m-%d")
+        start_date = Date.strptime(params[:start_date], "%Y-%m-%d")
+        if end_date < start_date
+          (errors[:end_date] ||= []) << "must be on or after start date"
         end
       rescue ArgumentError
       end
     end
-  end
 
-  rule(:name) do
-    if value.length < 3
-      key.failure("must be at least 3 characters long")
-    elsif value.length > 200
-      key.failure("must be no more than 200 characters long")
-    end
-  end
-
-  rule(:description) do
-    if value.length < 10
-      key.failure("must be at least 10 characters long")
-    elsif value.length > 1000
-      key.failure("must be no more than 1000 characters long")
-    end
-  end
-
-  rule(:location) do
-    if value.length < 3
-      key.failure("must be at least 3 characters long")
-    elsif value.length > 100
-      key.failure("must be no more than 100 characters long")
-    end
-  end
-
-  rule(:organizer) do
-    if value.length < 2
-      key.failure("must be at least 2 characters long")
-    elsif value.length > 100
-      key.failure("must be no more than 100 characters long")
-    end
-  end
-
-  rule(:category) do
-    unless VALID_CATEGORIES.include?(value)
-      key.failure("must be one of: #{VALID_CATEGORIES.join(", ")}")
-    end
-  end
-
-  rule(:event_link1, :event_link2, :event_link3, :event_link4) do
-    [values[:event_link1], values[:event_link2], values[:event_link3], values[:event_link4]].each_with_index do |link, index|
-      if link && !link.empty?
-        unless /\Ahttps?:\/\/.+\z/i.match?(link)
-          key(:"event_link#{index + 1}").failure("must be a valid URL starting with http:// or https://")
+    if params[:start_date] && params[:end_date] &&
+        params[:start_time] && params[:end_time] &&
+        !params[:start_time].to_s.empty? && !params[:end_time].to_s.empty? &&
+        params[:start_date] == params[:end_date]
+      begin
+        start_time = Time.parse(params[:start_time])
+        end_time = Time.parse(params[:end_time])
+        if end_time <= start_time
+          (errors[:end_time] ||= []) << "must be after start time when on the same date"
         end
-      end
-    end
-  end
-
-  rule(:contact_tel) do
-    if key? && value && !value.empty?
-      unless /\A[\d\s\-\(\)\+]+\z/.match?(value)
-        key.failure("must contain only numbers, spaces, hyphens, parentheses, and plus sign")
-      end
-
-      if value.gsub(/[\s\-\(\)\+]/, "").length < 7
-        key.failure("must contain at least 7 digits")
-      end
-    end
-  end
-
-  rule(:price_type) do
-    if key? && value && !value.empty?
-      unless VALID_PRICE_TYPES.include?(value)
-        key.failure("must be one of: #{VALID_PRICE_TYPES.join(", ")}")
+      rescue ArgumentError
       end
     end
   end

--- a/test/server/event_validation_test.rb
+++ b/test/server/event_validation_test.rb
@@ -32,7 +32,7 @@ class TestEventValidation < Minitest::Test
     }
     result = @validator.call(data)
     assert result.failure?, "Validation should fail for short name"
-    assert_includes result.errors.to_h[:name], "must be at least 3 characters long"
+    refute_empty result.errors[:name]
   end
 
   def test_invalid_start_date_format
@@ -47,7 +47,7 @@ class TestEventValidation < Minitest::Test
     }
     result = @validator.call(data)
     assert result.failure?, "Validation should fail for invalid start_date format"
-    assert_includes result.errors.to_h[:start_date], "must be a valid date format (YYYY-MM-DD)"
+    refute_empty result.errors[:start_date]
   end
 
   def test_end_date_before_start_date
@@ -62,7 +62,7 @@ class TestEventValidation < Minitest::Test
     }
     result = @validator.call(data)
     assert result.failure?, "Validation should fail when end_date is before start_date"
-    assert_includes result.errors.to_h[:end_date], "must be on or after start date"
+    refute_empty result.errors[:end_date]
   end
 
   def test_invalid_category
@@ -77,11 +77,7 @@ class TestEventValidation < Minitest::Test
     }
     result = @validator.call(data)
     assert result.failure?, "Validation should fail for invalid category"
-    valid_categories = [
-      "Música", "Comida", "Arte", "Natureza", "Saúde & Bem-Estar",
-      "Desporto", "Aprendizagem & Workshops", "Comunidade & Cultura"
-    ]
-    assert_includes result.errors.to_h[:category], "must be one of: #{valid_categories.join(", ")}"
+    refute_empty result.errors[:category]
   end
 
   def test_valid_optional_fields_empty
@@ -117,7 +113,7 @@ class TestEventValidation < Minitest::Test
     }
     result = @validator.call(data)
     assert result.failure?, "Validation should fail for invalid email"
-    assert_includes result.errors.to_h[:contact_email], "must be a valid email address"
+    refute_empty result.errors[:contact_email]
   end
 
   def test_invalid_phone_number_too_short
@@ -133,7 +129,7 @@ class TestEventValidation < Minitest::Test
     }
     result = @validator.call(data)
     assert result.failure?, "Validation should fail for short phone number"
-    assert_includes result.errors.to_h[:contact_tel], "must contain at least 7 digits"
+    refute_empty result.errors[:contact_tel]
   end
 
   def test_invalid_phone_number_characters
@@ -149,7 +145,7 @@ class TestEventValidation < Minitest::Test
     }
     result = @validator.call(data)
     assert result.failure?, "Validation should fail for phone number with invalid characters"
-    assert_includes result.errors.to_h[:contact_tel], "must contain only numbers, spaces, hyphens, parentheses, and plus sign"
+    refute_empty result.errors[:contact_tel]
   end
 
   def test_invalid_price_type
@@ -165,7 +161,7 @@ class TestEventValidation < Minitest::Test
     }
     result = @validator.call(data)
     assert result.failure?, "Validation should fail for invalid price_type"
-    assert_includes result.errors.to_h[:price_type], "must be one of: Gratuito, Pago, Desconhecido"
+    refute_empty result.errors[:price_type]
   end
 
   def test_invalid_event_link
@@ -181,7 +177,7 @@ class TestEventValidation < Minitest::Test
     }
     result = @validator.call(data)
     assert result.failure?, "Validation should fail for invalid event_link1"
-    assert_includes result.errors.to_h[:event_link1], "must be a valid URL starting with http:// or https://"
+    refute_empty result.errors[:event_link1]
   end
 
   def test_end_time_before_start_time_on_same_day
@@ -198,7 +194,7 @@ class TestEventValidation < Minitest::Test
     }
     result = @validator.call(data)
     assert result.failure?, "Validation should fail if end_time is before start_time on the same day"
-    assert_includes result.errors.to_h[:end_time], "must be after start time when on the same date"
+    refute_empty result.errors[:end_time]
   end
 
   def test_valid_event_with_all_optional_fields


### PR DESCRIPTION
## Summary
- add `json-schema` gem
- move field checks into `lib/server/event_schema.json`
- simplify `EventValidation` to use schema and keep relation checks
- ignore google token when validating params
- adjust tests for new message structure

## Testing
- `bundle exec rubocop -a`
- `rake test`

------
https://chatgpt.com/codex/tasks/task_e_68482f3de6fc832f9a533fdc9144425b