### PR TITLE
Normalize date format from form

### DIFF
--- a/bin/server.rb
+++ b/bin/server.rb
@@ -71,6 +71,20 @@ helpers do
       raise StandardError, "Image processing failed: #{e.message}"
     end
   end
+
+  # Convert HTML5 date input (yyyy-mm-dd) to dd/mm/YYYY expected by the
+  # validation layer. If the value is already in the desired format, it is
+  # returned unchanged. Any parsing errors fall back to the original string.
+  def normalize_date(date_str)
+    return "" if date_str.nil?
+    if /^\d{4}-\d{2}-\d{2}$/.match?(date_str)
+      Date.strptime(date_str, "%Y-%m-%d").strftime("%d/%m/%Y")
+    else
+      date_str
+    end
+  rescue ArgumentError
+    date_str
+  end
 end
 
 # Initialize Google Sheets service
@@ -206,6 +220,11 @@ post "/add_event" do
   validation_params = params.dup
   validation_params.delete(:event_image)
   validation_params.delete(:google_token)
+
+  # Convert dates from HTML5 format (yyyy-mm-dd) to the format expected by the
+  # validator (dd/mm/YYYY). Other formats pass through unchanged.
+  validation_params[:start_date] = normalize_date(validation_params[:start_date])
+  validation_params[:end_date] = normalize_date(validation_params[:end_date])
 
   # Validate the event data using dry-validation directly
   validator = EventValidation.new

--- a/test/server/events_post_endpoint_test.rb
+++ b/test/server/events_post_endpoint_test.rb
@@ -150,4 +150,20 @@ class AddEventEndpointTest < Minitest::Test
     assert_includes out, "price_type"
     assert_equal 0, app.settings.google_sheets.rows.length
   end
+
+  def test_iso_formatted_dates_are_converted
+    params = valid_params.merge(
+      start_date: "2025-12-01",
+      end_date: "2025-12-02"
+    )
+    out, _err = capture_io do
+      GoogleAuthService.stub :validate_token, {success: true, email: "user@example.com"} do
+        post "/add_event", params.merge(google_token: "token")
+      end
+    end
+    assert last_response.ok?, out
+    row = app.settings.google_sheets.rows.first
+    assert_equal "01/12/2025", row[3]
+    assert_equal "02/12/2025", row[5]
+  end
 end


### PR DESCRIPTION
## Summary
- ensure dates from the form (yyyy-mm-dd) are converted to dd/mm/YYYY
- add `normalize_date` helper in server
- test ISO date handling

## Testing
- `bundle exec rubocop -a`
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_68492f66d0c8832f87d02fd0a9493218