### PR TITLE
Add mobile dropdown filters

### DIFF
--- a/events_listing/assets/js/event-filter.js
+++ b/events_listing/assets/js/event-filter.js
@@ -4,6 +4,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const eventCards = document.querySelectorAll('.event-card');
   const filterButtons = document.querySelectorAll('#event-filter-controls .filter-btn');
+  const categorySelect = document.getElementById('category-select');
   const clearAllBtn = document.getElementById('clear-all-filters');
   const logoLink = document.getElementById('logo-link');
   let selectedCategory = 'all';
@@ -14,11 +15,18 @@ document.addEventListener('DOMContentLoaded', () => {
     const label = btn.dataset.label || btn.textContent.replace(/\s*\(.+\)$/, '');
     btn.dataset.label = label.trim();
   });
+  if (categorySelect) {
+    Array.from(categorySelect.options).forEach(opt => {
+      const label = opt.dataset.label || opt.textContent.replace(/\s*\(.+\)$/, '');
+      opt.dataset.label = label.trim();
+    });
+  }
 
   updateCategoryCounts();
   updateClearButtonVisibility(); // Initialize button visibility
 
   filterButtons.forEach(btn => btn.addEventListener('click', handleCategoryClick));
+  if (categorySelect) categorySelect.addEventListener('change', handleCategorySelect);
   document.addEventListener('calendar:dateSelected', e => { selectedRange = {start: e.detail.date, end: e.detail.date}; filterEvents(); });
   document.addEventListener('calendar:rangeSelected', e => { selectedRange = e.detail; filterEvents(); });
   document.addEventListener('calendar:clearDate', () => { selectedRange = null; filterEvents(); });
@@ -34,6 +42,21 @@ document.addEventListener('DOMContentLoaded', () => {
     });
     event.target.classList.remove('btn--inactive');
     event.target.classList.add('btn--active');
+    if (categorySelect) categorySelect.value = selectedCategory;
+    filterEvents();
+  }
+
+  function handleCategorySelect(event) {
+    selectedCategory = event.target.value;
+    document.querySelectorAll('#event-filter-controls .filter-btn').forEach(btn => {
+      if (btn.dataset.filterCategory === selectedCategory) {
+        btn.classList.add('btn--active');
+        btn.classList.remove('btn--inactive');
+      } else {
+        btn.classList.remove('btn--active');
+        btn.classList.add('btn--inactive');
+      }
+    });
     filterEvents();
   }
 
@@ -81,6 +104,17 @@ document.addEventListener('DOMContentLoaded', () => {
         btn.style.display = count ? '' : 'none';
       }
     });
+    if (categorySelect) {
+      Array.from(categorySelect.options).forEach(opt => {
+        const label = opt.dataset.label;
+        const category = opt.value;
+        const count = category === 'all' ? total : (counts[category] || 0);
+        opt.textContent = `${label} (${count})`;
+        if (category !== 'all') {
+          opt.hidden = count === 0;
+        }
+      });
+    }
   }
 
   function resetFilters() {
@@ -95,6 +129,7 @@ document.addEventListener('DOMContentLoaded', () => {
         btn.classList.add('btn--inactive');
       }
     });
+    if (categorySelect) categorySelect.value = 'all';
     document.dispatchEvent(new CustomEvent('calendar:reset'));
     filterEvents();
   }

--- a/events_listing/index.html
+++ b/events_listing/index.html
@@ -14,7 +14,7 @@ image: /assets/index_image.png
   {% assign sorted_groups = grouped | sort: "name" %}
 
   <div id="event-filter-controls" class="mb-4 flex flex-wrap items-center justify-between gap-2">
-    <div class="flex flex-wrap items-center gap-2">
+    <div class="hidden lg:flex flex-wrap items-center gap-2">
       <button data-filter-category="all" data-label="Todas as Categorias" class="filter-btn btn--active">
         Todas as Categorias ({{ future_events | size }})
       </button>
@@ -23,6 +23,17 @@ image: /assets/index_image.png
           {{ group.name | default: 'Evento' }} ({{ group.items | size }})
         </button>
       {% endfor %}
+    </div>
+    <div class="w-full lg:hidden">
+      <label for="category-select" class="sr-only">Categoria</label>
+      <select id="category-select" class="form-input">
+        <option value="all" data-label="Todas as Categorias">Todas as Categorias ({{ future_events | size }})</option>
+        {% for group in sorted_groups %}
+          <option value="{{ group.name | default: 'Evento' }}" data-label="{{ group.name | default: 'Evento' }}">
+            {{ group.name | default: 'Evento' }} ({{ group.items | size }})
+          </option>
+        {% endfor %}
+      </select>
     </div>
     <div id="clear-all-filters" class="hidden items-center gap-2">
       <button  class="navigation-button flex items-center gap-x-2 whitespace-nowrap" title="Limpar filtros">


### PR DESCRIPTION
## Summary
- replace category buttons with a select on mobile widths
- sync dropdown with button filters
- update filter script to manage option counts and selection

## Testing
- `bundle exec rubocop -a`
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_6849edf82d78832fbbd792cb9912ca6d