### PR TITLE
Add optional OCR event image usage

### DIFF
--- a/events_listing/event_ocr.html
+++ b/events_listing/event_ocr.html
@@ -21,6 +21,10 @@ sitemap: false
       <label for="event_image" class="form-label">Imagem <span class="text-red-500">*</span></label>
       <input type="file" name="event_image" id="event_image" required class="form-input file-input-button" />
     </div>
+    <div class="flex items-center space-x-2">
+      <input type="checkbox" name="use_event_image" id="use_event_image" checked class="form-checkbox" />
+      <label for="use_event_image" class="form-label m-0">Usar esta imagem nos eventos</label>
+    </div>
     <div>
       <button type="submit" id="submit-btn" class="navigation-button w-full sm:w-auto min-w-[10rem] flex items-center justify-center relative group" aria-live="polite">
         <span class="default-text transition-opacity duration-200 ease-in-out group-[.is-loading]:opacity-0 group-[.is-loading]:pointer-events-none">Enviar</span>


### PR DESCRIPTION
## Summary
- let users decide if the uploaded OCR image should also be stored with events
- save checkbox choice on the OCR form
- support the new parameter in backend and only upload when selected
- test both cases

## Testing
- `rubocop -a`
- `rake test`


------
https://chatgpt.com/codex/tasks/task_e_684bd5d7857c832fbcf2c950d7316f9c