### PR TITLE
Add be-a11y step to Docker Checks workflow

### DIFF
--- a/.github/workflows/docker_checks.yml
+++ b/.github/workflows/docker_checks.yml
@@ -71,3 +71,15 @@ jobs:
       - name: Run Tests
         run: |
           docker compose run --rm app rake test
+
+      - name: Build Jekyll site
+        run: |
+          docker compose run --rm app jekyll build --source events_listing --destination _site
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run be-a11y
+        run: npx @belenkadev/be-a11y _site


### PR DESCRIPTION
## Summary
- run be-a11y accessibility checks in CI

## Testing
- `bundle exec rubocop -a`
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_684c198ceb9c832fa5d652011240cbdf