### PR TITLE
Optimize event images to improve LCP

### DIFF
--- a/events_listing/_layouts/default.html
+++ b/events_listing/_layouts/default.html
@@ -21,6 +21,9 @@
     <link rel="stylesheet" type="text/css" href="/assets/css/styles.css">
 
     {% seo %}
+    {% if page.image %}
+    <link rel="preload" as="image" href="{{ page.image | relative_url }}" fetchpriority="high">
+    {% endif %}
   </head>
   <body class="bg-neutral-100 font-sans flex flex-col min-h-screen">
     {% include header.html %}

--- a/events_listing/_layouts/event.html
+++ b/events_listing/_layouts/event.html
@@ -15,6 +15,9 @@ layout: default
           style="max-height: 400px; object-fit: contain;"
           width="896"
           height="400"
+          loading="eager"
+          fetchpriority="high"
+          decoding="async"
         />
       </a>
       <div id="image-modal" class="hidden fixed inset-0 z-50 items-center justify-center">


### PR DESCRIPTION
## Summary
- preload event images in the default layout
- mark event images as high priority

## Testing
- `bundle exec rubocop -a`
- `rake test`

------
https://chatgpt.com/codex/tasks/task_e_684c694dc818832f9392af418f0bbe4f