### PR TITLE
Add missing 404 page and fix logo redirect

### DIFF
--- a/events_listing/404.html
+++ b/events_listing/404.html
@@ -1,0 +1,14 @@
+---
+layout: default
+title: "Página não encontrada"
+permalink: /404.html
+sitemap: false
+---
+
+<div class="text-center py-12">
+  <div class="max-w-md mx-auto">
+    <h1 class="text-4xl font-bold mb-4">Página não encontrada</h1>
+    <p class="muted-text mb-8">A página que procurou não existe.</p>
+    <a href="/" class="navigation-button">Voltar à página inicial</a>
+  </div>
+</div>

--- a/events_listing/assets/js/event-filter.js
+++ b/events_listing/assets/js/event-filter.js
@@ -25,7 +25,12 @@ document.addEventListener('DOMContentLoaded', () => {
   document.addEventListener('calendar:clearDate', () => { selectedRange = null; filterEvents(); });
   if (clearAllBtn) clearAllBtn.addEventListener('click', resetFilters);
   document.addEventListener('filters:reset', resetFilters);
-  if (logoLink) logoLink.addEventListener('click', e => { e.preventDefault(); document.dispatchEvent(new CustomEvent('filters:reset')); });
+  if (logoLink) logoLink.addEventListener('click', e => {
+    if (window.location.pathname === '/' || window.location.pathname === '/index.html') {
+      e.preventDefault();
+      document.dispatchEvent(new CustomEvent('filters:reset'));
+    }
+  });
 
   function handleCategoryChange(event) {
     selectedCategory = event.target.value;


### PR DESCRIPTION
## Summary
- create a 404 page so invalid URLs show an error
- allow the logo click on the events page to navigate to `/` when not already on the homepage

## Testing
- `rubocop -a`
- `rake test`


------
https://chatgpt.com/codex/tasks/task_e_685909bbc6a8832fa28fd4f1416fbfab