### PR TITLE
Fix console warnings

### DIFF
--- a/events_listing/_layouts/default.html
+++ b/events_listing/_layouts/default.html
@@ -20,7 +20,10 @@
 
     <link rel="stylesheet" type="text/css" href="/assets/css/styles.css">
 
-      {% seo %}
+    {% seo %}
+    {% if page.image and page.url != '/' %}
+    <link rel="preload" as="image" href="{{ page.image | relative_url }}" fetchpriority="high">
+    {% endif %}
   </head>
   <body class="bg-neutral-100 font-sans flex flex-col min-h-screen">
     {% include header.html %}

--- a/events_listing/_layouts/default.html
+++ b/events_listing/_layouts/default.html
@@ -20,10 +20,7 @@
 
     <link rel="stylesheet" type="text/css" href="/assets/css/styles.css">
 
-    {% seo %}
-    {% if page.image %}
-    <link rel="preload" as="image" href="{{ page.image | relative_url }}" fetchpriority="high">
-    {% endif %}
+      {% seo %}
   </head>
   <body class="bg-neutral-100 font-sans flex flex-col min-h-screen">
     {% include header.html %}

--- a/events_listing/assets/js/pwa-install.js
+++ b/events_listing/assets/js/pwa-install.js
@@ -5,9 +5,7 @@ document.addEventListener('DOMContentLoaded', () => {
   let deferredPrompt;
 
   window.addEventListener('beforeinstallprompt', (e) => {
-    // Prevent Chrome 67 and earlier from automatically showing the prompt
-    e.preventDefault();
-    // Stash the event so it can be triggered later.
+    // Store the event so it can be triggered later.
     deferredPrompt = e;
     // Update UI to notify the user they can add to home screen
     if (installBanner) {


### PR DESCRIPTION
## Summary
- stop preloading unused index image
- simplify PWA install handler to avoid Chrome warning

## Testing
- `bundle exec rubocop -a`
- `rake test`

------
https://chatgpt.com/codex/tasks/task_e_685a5f7c2fe0832fa310a3d9d0b982c9