### PR TITLE
Fix PWA manifest usage

### DIFF
--- a/events_listing/_layouts/default.html
+++ b/events_listing/_layouts/default.html
@@ -8,7 +8,8 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/assets/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/favicon-16x16.png">
-    <link rel="manifest" href="/assets/site.webmanifest">
+    <link rel="manifest" href="{{ '/assets/site.webmanifest' | relative_url }}" crossorigin="anonymous">
+    <meta name="application-name" content="PXO Pulse - Porto Santo Events">
     <meta name="msapplication-config" content="/assets/browserconfig.xml">
     <meta name="theme-color" content="#75c8e2">
 

--- a/events_listing/assets/site.webmanifest
+++ b/events_listing/assets/site.webmanifest
@@ -43,13 +43,13 @@
             "src": "/assets/android-chrome-192x192-maskable.png",
             "sizes": "192x192",
             "type": "image/png",
-            "purpose": "maskable"
+            "purpose": "any maskable"
         },
         {
             "src": "/assets/android-chrome-512x512-maskable.png",
             "sizes": "512x512",
             "type": "image/png",
-            "purpose": "maskable"
+            "purpose": "any maskable"
         }
     ]
 }


### PR DESCRIPTION
## Summary
- fix manifest link using `relative_url`
- declare `application-name` meta tag
- set maskable icons as preferred

## Testing
- `bundle exec rubocop -a`
- `rake test`


------
https://chatgpt.com/codex/tasks/task_e_685a67f42480832fbf2420f5677f0759