### PR TITLE
Reduce category filter JS work

### DIFF
--- a/events_listing/assets/js/event-filter.js
+++ b/events_listing/assets/js/event-filter.js
@@ -16,7 +16,6 @@ document.addEventListener('DOMContentLoaded', () => {
     opt.dataset.label = label.trim();
   });
 
-  updateCategoryCounts();
   updateClearButtonVisibility(); // Initialize button visibility
 
   if (categorySelect) categorySelect.addEventListener('change', handleCategoryChange);
@@ -34,11 +33,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function handleCategoryChange(event) {
     selectedCategory = event.target.value;
-    filterEvents();
+    filterEvents(false); // don't recalc counts on category change
   }
 
-  function filterEvents() {
-    updateCategoryCounts();
+  function filterEvents(shouldUpdateCounts = true) {
+    if (shouldUpdateCounts) updateCategoryCounts();
     updateClearButtonVisibility();
     eventCards.forEach(card => {
       const cardCategory = card.dataset.category;

--- a/events_listing/assets/js/event-filter.js
+++ b/events_listing/assets/js/event-filter.js
@@ -37,13 +37,18 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   function filterEvents(shouldUpdateCounts = true) {
-    if (shouldUpdateCounts) updateCategoryCounts();
+    const applyCategory = selectedCategory !== 'all';
+    const applyRange = selectedRange !== null;
+
+    if (shouldUpdateCounts && applyRange) updateCategoryCounts();
     updateClearButtonVisibility();
+    if (!applyCategory && !applyRange) return;
+
     eventCards.forEach(card => {
       const cardCategory = card.dataset.category;
       const cardDate = card.dataset.date;
-      const matchCategory = selectedCategory === 'all' || cardCategory === selectedCategory;
-      const matchDate = !selectedRange || (cardDate >= selectedRange.start && cardDate <= selectedRange.end);
+      const matchCategory = !applyCategory || cardCategory === selectedCategory;
+      const matchDate = !applyRange || (cardDate >= selectedRange.start && cardDate <= selectedRange.end);
       card.style.display = matchCategory && matchDate ? 'flex' : 'none';
     });
   }


### PR DESCRIPTION
## Summary
- avoid initial category count recalculation
- skip count updates on category changes

## Testing
- `rubocop -a`
- `rake test`


------
https://chatgpt.com/codex/tasks/task_e_68626e2399ec832fb3dfe8d4fc68cb91