### PR TITLE
Fix CLS by reserving calendar height

### DIFF
--- a/events_listing/_tailwind.css
+++ b/events_listing/_tailwind.css
@@ -134,6 +134,7 @@
 .calendar-grid {
   @apply grid text-center text-sm overflow-hidden border-gray-200 bg-white;
   grid-template-columns: 2rem repeat(7,minmax(0,1fr));
+  @apply min-h-[28rem];
 }
 
 


### PR DESCRIPTION
## Summary
- fix layout shift by reserving calendar height with `min-h-[28rem]`

## Testing
- `bundle exec rubocop -a`
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_686292da65a8832fbec4236bb121ae12