### PR TITLE
Fix CLS issue on event page

### DIFF
--- a/events_listing/index.html
+++ b/events_listing/index.html
@@ -43,18 +43,6 @@ image: /assets/index_image.png
     {% include calendar.html %}
   </div>
 
-  <!-- PWA Install Banner (Mobile Only) -->
-  <div id="pwa-install-banner" class="fixed bottom-0 left-0 right-0 md:hidden bg-gray-700 p-3 text-white shadow-lg z-50 hidden">
-    <div class="container mx-auto flex items-center justify-between gap-2">
-      <span class="text-sm">Instale a nossa app para uma melhor experiência!</span>
-      <div class="flex items-center flex-shrink-0">
-        <button id="install-pwa-btn" class="bg-[var(--color-buttons)] hover:bg-[var(--color-buttons-hover)] text-[var(--color-text-secondary)] py-1 px-3 rounded text-sm mr-2 whitespace-nowrap">
-          Instalar
-        </button>
-        <button id="close-pwa-banner-btn" class="text-gray-400 hover:text-white text-2xl leading-none p-2 cursor-pointer">&times;</button>
-      </div>
-    </div>
-  </div>
 
   <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 auto-rows-fr gap-6">
     {% assign sorted_events = future_events %}
@@ -84,6 +72,19 @@ image: /assets/index_image.png
     {% endfor %}
   </div>
 </section>
+
+<!-- PWA Install Banner (Mobile Only) -->
+<div id="pwa-install-banner" class="fixed bottom-0 left-0 right-0 md:hidden bg-gray-700 p-3 text-white shadow-lg z-50 hidden">
+  <div class="container mx-auto flex items-center justify-between gap-2">
+    <span class="text-sm">Instale a nossa app para uma melhor experiência!</span>
+    <div class="flex items-center flex-shrink-0">
+      <button id="install-pwa-btn" class="bg-[var(--color-buttons)] hover:bg-[var(--color-buttons-hover)] text-[var(--color-text-secondary)] py-1 px-3 rounded text-sm mr-2 whitespace-nowrap">
+        Instalar
+      </button>
+      <button id="close-pwa-banner-btn" class="text-gray-400 hover:text-white text-2xl leading-none p-2 cursor-pointer">&times;</button>
+    </div>
+  </div>
+</div>
 
 <div class="container mx-auto px-4 sm:px-6 mb-12 text-center">
   <p class="muted-text mb-4">


### PR DESCRIPTION
## Summary
- move PWA install banner outside of event list

## Testing
- `bundle exec rubocop -A`
- `bundle exec rake test`


------
https://chatgpt.com/codex/tasks/task_e_686292da65a8832fbec4236bb121ae12