### PR TITLE
Refactor image upload handling

### DIFF
--- a/bin/server.rb
+++ b/bin/server.rb
@@ -44,21 +44,21 @@ helpers do
     json_response(response_data, 200)
   end
 
+  def upload_image_if_production(image_path)
+    if settings.environment == :production
+      GitHubService.upload_image(image_path)
+      puts "✅ Image uploaded to GitHub (production)"
+    else
+      puts "ℹ️ Skipping GitHub upload (not in production environment)"
+    end
+  end
+
   def process_event_image(event_image)
     return "" unless event_image && event_image[:tempfile]
 
     begin
       image_path = ImageService.validate_and_process(event_image)
-
-      # Upload to GitHub only in production environment
-      if settings.environment == :production
-        # Get the full file path for GitHub upload
-        GitHubService.upload_image(image_path)
-        puts "✅ Image uploaded to GitHub (production)"
-      else
-        puts "ℹ️ Skipping GitHub upload (not in production environment)"
-      end
-
+      upload_image_if_production(image_path)
       image_path
     rescue => e
       puts "❌ Image processing error: #{e.message}"

--- a/bin/server.rb
+++ b/bin/server.rb
@@ -48,15 +48,7 @@ helpers do
     return "" unless event_image && event_image[:tempfile]
 
     begin
-      # Validate the image
-      validation_error = ImageService.validate_upload(event_image)
-      if validation_error
-        raise StandardError, validation_error
-      end
-
-      # Process the image
-      image_path = ImageService.process_upload(event_image)
-      puts "✅ Image processed successfully: #{image_path}"
+      image_path = ImageService.validate_and_process(event_image)
 
       # Upload to GitHub only in production environment
       if settings.environment == :production
@@ -188,12 +180,10 @@ post "/events_ocr" do
 
   begin
     use_image = params[:use_event_image]
-    if use_image
-      image_path = process_event_image(params[:event_image])
+    image_path = if use_image
+      process_event_image(params[:event_image])
     else
-      err = ImageService.validate_upload(params[:event_image])
-      raise StandardError, err if err
-      image_path = ImageService.process_upload(params[:event_image])
+      ImageService.validate_and_process(params[:event_image])
     end
     events = EventOcrService.call(image_path) # Assuming this returns an array of event structures
 

--- a/lib/server/image_service.rb
+++ b/lib/server/image_service.rb
@@ -83,4 +83,13 @@ class ImageService
 
     nil # No errors
   end
+
+  def self.validate_and_process(uploaded_file)
+    validation_error = validate_upload(uploaded_file)
+    raise StandardError, validation_error if validation_error
+
+    image_path = process_upload(uploaded_file)
+    puts "✅ Image processed successfully: #{image_path}"
+    image_path
+  end
 end

--- a/test/server/event_image_endpoint_test.rb
+++ b/test/server/event_image_endpoint_test.rb
@@ -35,10 +35,11 @@ class EventImageEndpointTest < Minitest::Test
   def test_successful_upload
     out, _err = capture_io do
       GoogleAuthService.stub :validate_token, {success: true, email: SecurityService::WHITELISTED_EMAILS.first} do
-        ImageService.stub :validate_upload, nil do
-          ImageService.stub :process_upload, "/tmp/test.webp" do
-            post "/event_image", {google_token: "token", event_image: Rack::Test::UploadedFile.new(__FILE__, "image/png")}
-          end
+        ImageService.stub :validate_and_process, ->(file) {
+          puts "✅ Image processed successfully: /tmp/test.webp"
+          "/tmp/test.webp"
+        } do
+          post "/event_image", {google_token: "token", event_image: Rack::Test::UploadedFile.new(__FILE__, "image/png")}
         end
       end
     end

--- a/test/server/events_ocr_endpoint_test.rb
+++ b/test/server/events_ocr_endpoint_test.rb
@@ -63,14 +63,12 @@ class EventsOcrEndpointTest < Minitest::Test
     out, _err = capture_io do
       EventOcrService.stub :call, [valid_event] do
         GoogleAuthService.stub :validate_token, {success: true, email: SecurityService::WHITELISTED_EMAILS.first} do
-          ImageService.stub :validate_upload, nil do
-            ImageService.stub :process_upload, "/tmp/test.webp" do
-              post "/events_ocr", {
-                google_token: "token",
-                event_image: Rack::Test::UploadedFile.new(__FILE__, "image/png"),
-                use_event_image: "on"
-              }
-            end
+          ImageService.stub :validate_and_process, "/tmp/test.webp" do
+            post "/events_ocr", {
+              google_token: "token",
+              event_image: Rack::Test::UploadedFile.new(__FILE__, "image/png"),
+              use_event_image: "on"
+            }
           end
         end
       end
@@ -90,13 +88,11 @@ class EventsOcrEndpointTest < Minitest::Test
     out, _err = capture_io do
       EventOcrService.stub :call, [valid_event] do
         GoogleAuthService.stub :validate_token, {success: true, email: SecurityService::WHITELISTED_EMAILS.first} do
-          ImageService.stub :validate_upload, nil do
-            ImageService.stub :process_upload, "/tmp/test.webp" do
-              post "/events_ocr", {
-                google_token: "token",
-                event_image: Rack::Test::UploadedFile.new(__FILE__, "image/png")
-              }
-            end
+          ImageService.stub :validate_and_process, "/tmp/test.webp" do
+            post "/events_ocr", {
+              google_token: "token",
+              event_image: Rack::Test::UploadedFile.new(__FILE__, "image/png")
+            }
           end
         end
       end


### PR DESCRIPTION
## Summary
- extract validation and processing into `ImageService.validate_and_process`
- reuse new method from server helpers and OCR endpoint
- adjust tests for new method

## Testing
- `rubocop -a`
- `rake test`


------
https://chatgpt.com/codex/tasks/task_e_6863b0f955ac832f9b57262ab1f71db3