### PR TITLE
Allow workflow_dispatch to publish CI image

### DIFF
--- a/.github/workflows/docker_checks.yml
+++ b/.github/workflows/docker_checks.yml
@@ -85,7 +85,7 @@ jobs:
           config: .hadolint.yaml
 
       - name: Login to GitHub Container Registry
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -99,7 +99,7 @@ jobs:
       - name: Build
         uses: docker/build-push-action@v7
         with:
-          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          push: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
           load: true
           cache-from: type=gha,scope=ci
           cache-to: type=gha,mode=max,scope=ci

--- a/.github/workflows/docker_checks.yml
+++ b/.github/workflows/docker_checks.yml
@@ -84,6 +84,9 @@ jobs:
           dockerfile: Dockerfile
           config: .hadolint.yaml
 
+      # This guard was added when Docker Checks started running on PRs: PR builds
+      # must never overwrite the shared :ci tag. Checking the ref instead of only
+      # event_name == 'push' also allows workflow_dispatch on main to republish it.
       - name: Login to GitHub Container Registry
         if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/login-action@v4

--- a/.github/workflows/docker_checks.yml
+++ b/.github/workflows/docker_checks.yml
@@ -85,7 +85,7 @@ jobs:
           config: .hadolint.yaml
 
       - name: Login to GitHub Container Registry
-        if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -99,7 +99,7 @@ jobs:
       - name: Build
         uses: docker/build-push-action@v7
         with:
-          push: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
+          push: ${{ github.ref == 'refs/heads/main' }}
           load: true
           cache-from: type=gha,scope=ci
           cache-to: type=gha,mode=max,scope=ci


### PR DESCRIPTION
## Summary

Allow manually triggered `Docker Checks` runs on `main` to authenticate to GHCR and push the rebuilt `:ci` image.

## Why

After dependency-only updates such as `mini_magick 5.3.3`, a manual `Docker Checks` run rebuilt and validated the image locally but did not publish it because publishing was restricted to `push` events. Scheduled workflows then kept pulling the stale `ghcr.io/zewelor/ps_events:ci` image and failed with `Bundler::GemNotFound`.

This keeps PR behavior unchanged and only adds `workflow_dispatch` on `main` as an allowed publishing path.